### PR TITLE
Linting fixes from buildifier

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 # Go boilerplate
 load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
-go_prefix("github.com/GoogleCloudPlatform/distroless")
 
+go_prefix("github.com/GoogleCloudPlatform/distroless")

--- a/base/BUILD
+++ b/base/BUILD
@@ -12,5 +12,9 @@ docker_build(
 docker_build(
     name = "base",
     base = ":with_tmp",
-    debs = ["@glibc//file", "@libssl//file", "@openssl//file"],
+    debs = [
+        "@glibc//file",
+        "@libssl//file",
+        "@openssl//file",
+    ],
 )


### PR DESCRIPTION
fixes from `buildifier -mode=fix $(find . -name BUILD -o -name '*.bzl' -type f)`