### PR TITLE
Add ca_certificates to base image

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -16,5 +16,6 @@ docker_build(
         "@glibc//file",
         "@libssl//file",
         "@openssl//file",
+        "@ca_certificates//file",
     ],
 )


### PR DESCRIPTION
It was added in the workspace, but not in the base image

fixes #9 