### PR TITLE
Add a default /etc/passwd with a root user.

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -10,8 +10,14 @@ docker_build(
 )
 
 docker_build(
+    name = "with_passwd",
+    directory = "/etc",
+    files = [":passwd"]
+)
+
+docker_build(
     name = "base",
-    base = ":with_tmp",
+    base = ":with_passwd",
     debs = [
         "@glibc//file",
         "@libssl//file",

--- a/base/passwd
+++ b/base/passwd
@@ -1,0 +1,1 @@
+root:x:0:0:root:/root:/noshell


### PR DESCRIPTION
This adds a default /etc/passwd for a root user.

Without this, a simple Go program to find the current user fails:

```golang
package main

import (
	"fmt"
	"os"
	"os/user"
)

func main() {
	u, err := user.Current()
	if err != nil {
		fmt.Println("Error getting user: ", err)
		os.Exit(1)
	}
	fmt.Printf("USER: %s\n", u)
}
```
with:
```shell
Error getting user:  user: lookup userid 0: no such file or directory
```

With this, the program runs correctly:
```shell
USER: &{0 0 root root /root}
```

We might also want to create the /root directory.