### PR TITLE
Add a busybox-based debug container.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ install:
 script:
   - bazel clean && bazel build //...
 # We don't have any tests yet so this fails. Uncomment when we do.
-#  - bazel clean && bazel test --test_output=errors //...
+  - bazel build //base:base.tar && docker load -i bazel-bin/base/base.tar && bazel run //base:base
+  - bazel test --test_output=errors //...
   - ./buildifier.sh
 
 notifications:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,6 +35,13 @@ http_file(
     sha256 = "d3819ceeb2becc96aea4b0fceda48f6e68f84193526bc67f6895c00796ee99d6",
 )
 
+# For the debug image
+http_file(
+    name = "busybox",
+    executable = True,
+    url = "https://busybox.net/downloads/binaries/1.21.1/busybox-x86_64"
+)
+
 # For Java
 http_file(
    name = "zlib",
@@ -44,8 +51,8 @@ http_file(
 
 http_file(
    name = "openjdk_jre8",
-   url = "http://ftp.us.debian.org/debian/pool/main/o/openjdk-8/openjdk-8-jdk-headless_8u131-b11-1~bpo8+1_amd64.deb",
-   sha256 = "b3f04e909020084479aabfb2dbc3dc3bd109ece84a112440c37e5a2cfd67a125",
+   url = "http://ftp.us.debian.org/debian/pool/main/o/openjdk-8/openjdk-8-jre-headless_8u131-b11-1~bpo8+1_amd64.deb",
+   sha256 = "11c592e237549d74bda30875979c2a937588667d10307c7c14047b8d03f5718a",
 )
 
 http_file(
@@ -82,3 +89,9 @@ load(
 )
 
 docker_repositories()
+
+git_repository(
+    name = "runtimes_common",
+    remote = "https://github.com/GoogleCloudPlatform/runtimes-common.git",
+    commit = "4e9b3b57efb237ba09b4a319bea42bcdd4eb91e3",
+)

--- a/base/BUILD
+++ b/base/BUILD
@@ -28,3 +28,30 @@ docker_build(
         "@libstdcpp6//file",
     ],
 )
+
+load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+
+structure_test(
+    name = "base_test",
+    config = "testdata/base.yaml",
+    image = ":base",
+)
+
+# For convenience, rename busybox-x86_64 to busybox.
+genrule(
+    name = "_busybox",
+    srcs = ["@busybox//file"],
+    outs = ["busybox"],
+    cmd = "mv $(<) $(@)",
+    visibility = ["//visibility:private"],
+)
+
+# A debug image with busybox available.
+docker_build(
+    name = "debug",
+    base = ":cc",
+    entrypoint = ["/busybox"],
+    files = [
+        ":busybox",
+    ],
+)

--- a/base/BUILD
+++ b/base/BUILD
@@ -42,7 +42,7 @@ genrule(
     name = "_busybox",
     srcs = ["@busybox//file"],
     outs = ["busybox"],
-    cmd = "mv $(<) $(@)",
+    cmd = "cp $(<) $(@)",
     visibility = ["//visibility:private"],
 )
 
@@ -54,4 +54,10 @@ docker_build(
     files = [
         ":busybox",
     ],
+)
+
+structure_test(
+    name = "debug_test",
+    config = "testdata/debug.yaml",
+    image = ":debug",
 )

--- a/base/test.sh
+++ b/base/test.sh
@@ -1,0 +1,4 @@
+$RUNFILES_DIR/runtimes_common/structure_tests/ext_run.sh \
+  -i bazel/base:cc \
+  -t $RUNFILES_DIR/distroless/base/base.tar \
+  -c $RUNFILES_DIR/distroless/base/testdata/base.yaml

--- a/base/testdata/base.yaml
+++ b/base/testdata/base.yaml
@@ -1,0 +1,11 @@
+schemaVersion: "1.0.0"
+fileExistenceTests:
+# Basic FS sanity checks.
+- name: root
+  path: '/'
+  isDirectory: true
+  shouldExist: true
+- name: tmp
+  path: '/tmp'
+  isDirectory: true
+  shouldExist: true

--- a/base/testdata/debug.yaml
+++ b/base/testdata/debug.yaml
@@ -1,0 +1,10 @@
+schemaVersion: "1.0.0"
+fileExistenceTests:
+# Basic FS sanity checks.
+- name: busybox
+  path: '/busybox'
+  shouldExist: true
+commandTests:
+  - name: busybox
+    command: ["/busybox"]
+    expectedOutput: ['BusyBox v1\.21\.1']

--- a/java/BUILD
+++ b/java/BUILD
@@ -16,3 +16,11 @@ docker_build(
         # cmd = ["/path/to/deploy.jar", "--option1", ...]
     ],
 )
+
+load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+
+structure_test(
+    name = "java8_test",
+    config = "testdata/java.yaml",
+    image = ":java8",
+)

--- a/java/examples/BUILD
+++ b/java/examples/BUILD
@@ -13,3 +13,11 @@ docker_build(
     cmd = ["/HelloJava_deploy.jar"],
     files = [":HelloJava_deploy.jar"],
 )
+
+load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+
+structure_test(
+    name = "hello_test",
+    config = "testdata/hello.yaml",
+    image = ":hello",
+)

--- a/java/examples/testdata/hello.yaml
+++ b/java/examples/testdata/hello.yaml
@@ -1,0 +1,5 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: hello
+    command: ["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java", "-jar", "HelloJava_deploy.jar"]
+    expectedOutput: ['Hello world']

--- a/java/testdata/java.yaml
+++ b/java/testdata/java.yaml
@@ -1,0 +1,5 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: java
+    command: ["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java", "-version"]
+    expectedError: ['openjdk version "1\.8.*"']


### PR DESCRIPTION
This was really useful in tracking down an issue with the jetty container I'm working on.

Usage:
```shell
docker run -it bazel/base:debug ash
```

cc @mattmoor @r2d4 