### PR TITLE
dpkg and dpkg_src rules for deb packages

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,42 +10,64 @@ load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
 
 go_repositories()
 
+load(
+    "//package_manager:package_manager.bzl",
+    "package_manager_repositories",
+    "dpkg_src",
+    "dpkg",
+)
+
+package_manager_repositories()
+
+dpkg_src(
+    name = "debian_jessie",
+    arch = "amd64",
+    distro = "jessie",
+    url = "http://deb.debian.org",
+)
+
+dpkg_src(
+    name = "debian_jessie_backports",
+    arch = "amd64",
+    distro = "jessie-backports",
+    url = "http://deb.debian.org",
+)
+
 # For the glibc base image.
-http_file(
-    name = "glibc",
-    sha256 = "bdf12aa461f2960251292c9dbfa2702d65105555b12cb36c6ac9bf8bea10b382",
-    url = "http://deb.debian.org/debian/pool/main/g/glibc/libc6_2.19-18+deb8u9_amd64.deb",
+dpkg(
+    name = "libc6",
+    source = "@debian_jessie//file:Packages.json",
 )
 
-http_file(
-    name = "ca_certificates",
-    sha256 = "bd799f47f5ae3260b6402b1fe19fe2c37f2f4125afcd19327bf69a9cf436aeff",
-    url = "http://deb.debian.org/debian/pool/main/c/ca-certificates/ca-certificates_20141019+deb8u3_all.deb",
+dpkg(
+    name = "ca-certificates",
+    source = "@debian_jessie//file:Packages.json",
 )
 
-http_file(
+dpkg(
     name = "openssl",
-    sha256 = "41613658b4e93ffaa7de25060a4a1ab2f8dfa1ee15ed90aeac850a9bf5a134bb",
-    url = "http://deb.debian.org/debian/pool/main/o/openssl/openssl_1.0.1t-1+deb8u6_amd64.deb",
+    source = "@debian_jessie//file:Packages.json",
 )
 
-http_file(
-    name = "libssl",
-    sha256 = "9c8637febf6a32c300bebd1eaa8d78f3845dd6d87d8c5e56345e5fc5f3041034",
-    url = "http://deb.debian.org/debian/pool/main/o/openssl/libssl1.1-udeb_1.1.0f-3_amd64.udeb",
+dpkg(
+    name = "libssl1.0.0",
+    source = "@debian_jessie//file:Packages.json",
 )
 
 # For Java
-http_file(
-    name = "zlib",
-    sha256 = "b75102f61ace79c14ea6f06fdd9509825ee2af694c6aa503253df4e6659d6772",
-    url = "http://deb.debian.org/debian/pool/main/z/zlib/zlib1g_1.2.8.dfsg-2+b1_amd64.deb",
+dpkg(
+    name = "zlib1g",
+    source = "@debian_jessie//file:Packages.json",
 )
 
-http_file(
-    name = "openjdk_jre8",
-    sha256 = "11c592e237549d74bda30875979c2a937588667d10307c7c14047b8d03f5718a",
-    url = "http://deb.debian.org/debian/pool/main/o/openjdk-8/openjdk-8-jre-headless_8u131-b11-1~bpo8+1_amd64.deb",
+dpkg(
+    name = "openjdk-8-jre-headless",
+    source = "@debian_jessie_backports//file:Packages.json",
+)
+
+dpkg(
+    name = "libgcc1",
+    source = "@debian_jessie//file:Packages.json",
 )
 
 http_file(
@@ -54,10 +76,20 @@ http_file(
     url = "http://deb.debian.org/debian/pool/main/g/gcc-4.9/libstdc++6_4.9.2-10_amd64.deb",
 )
 
-http_file(
-    name = "libgcc1",
-    sha256 = "a1402290165e8d91b396a33d79580a4501041e92bdb62ef23929a0c207cd9af9",
-    url = "http://deb.debian.org/debian/pool/main/g/gcc-4.9/libgcc1_4.9.2-10_amd64.deb",
+# For Python
+dpkg(
+    name = "libpython2.7-minimal",
+    source = "@debian_jessie//file:Packages.json",
+)
+
+dpkg(
+    name = "python2.7-minimal",
+    source = "@debian_jessie//file:Packages.json",
+)
+
+dpkg(
+    name = "libpython2.7-stdlib",
+    source = "@debian_jessie//file:Packages.json",
 )
 
 # For Jetty
@@ -68,25 +100,6 @@ new_http_archive(
     strip_prefix = "jetty-distribution-9.4.4.v20170414/",
     type = "tgz",
     url = "http://central.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.4.v20170414/jetty-distribution-9.4.4.v20170414.tar.gz",
-)
-
-# For Python
-http_file(
-    name = "libpython27",
-    sha256 = "916e2c541aa954239cb8da45d1d7e4ecec232b24d3af8982e76bf43d3e1758f3",
-    url = "http://deb.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.9-2+deb8u1_amd64.deb",
-)
-
-http_file(
-    name = "python27",
-    sha256 = "c89199f908d5a508d8d404efc0e1aef3d9db59ea23bd4532df9e59941643fcfb",
-    url = "http://deb.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.9-2+deb8u1_amd64.deb",
-)
-
-http_file(
-    name = "libpython27_stdlib",
-    sha256 = "d997ef9edbccea4f1902a443a31c26c5c62cc5e2c9a679b3ace19909c8dc9f31",
-    url = "http://deb.debian.org/debian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.13-2_amd64.deb",
 )
 
 # Node

--- a/base/BUILD
+++ b/base/BUILD
@@ -32,9 +32,9 @@ docker_build(
     name = "base",
     base = ":with_tmp",
     debs = [
-        "@glibc//file",
-        "@libssl//file",
-        "@openssl//file",
+        "@libc6//file:pkg.deb",
+        "@libssl1.0.0//file:pkg.deb",
+        "@openssl//file:pkg.deb",
     ],
     tars = [
         ":base_passwd.passwd.tar",

--- a/cacerts/cacerts.bzl
+++ b/cacerts/cacerts.bzl
@@ -9,7 +9,7 @@ def _impl(ctx):
 cacerts = rule(
     attrs = {
         "deb": attr.label(
-            default = Label("@ca_certificates//file"),
+            default = Label("@ca-certificates//file:pkg.deb"),
             allow_files = [".deb"],
             single_file = True,
         ),

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -7,7 +7,7 @@ docker_build(
     name = "cc",
     base = "//base:base",
     debs = [
-        "@libgcc1//file",
+        "@libgcc1//file:pkg.deb",
         "@libstdcpp6//file",
     ],
 )

--- a/java/BUILD
+++ b/java/BUILD
@@ -6,8 +6,8 @@ docker_build(
     name = "java8",
     base = "//cc:cc",
     debs = [
-        "@zlib//file",
-        "@openjdk_jre8//file",
+        "@zlib1g//file:pkg.deb",
+        "@openjdk-8-jre-headless//file:pkg.deb",
     ],
     entrypoint = [
         "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",

--- a/package_manager/BUILD
+++ b/package_manager/BUILD
@@ -1,0 +1,22 @@
+load("@subpar//:subpar.bzl", "par_binary")
+
+par_binary(
+    name = "dpkg_parser",
+    srcs = glob(["**/*.py"]),
+    main = "dpkg_parser.py",
+    visibility = ["//visibility:public"],
+    deps = [":parse_metadata"],
+)
+
+py_library(
+    name = "parse_metadata",
+    srcs = ["parse_metadata.py"],
+)
+
+py_test(
+    name = "parse_metadata_test",
+    size = "small",
+    srcs = ["parse_metadata_test.py"],
+    data = ["testdata/Packages.txt"],
+    deps = [":parse_metadata"],
+)

--- a/package_manager/cloudbuild.yaml
+++ b/package_manager/cloudbuild.yaml
@@ -1,0 +1,29 @@
+# A cloud build config to release a PAR binary of
+# the dpkg_parser.par used for the package manager bazel rules
+
+# A cloudbuild is triggered by every commit and $COMMIT_SHA is a built-in 
+# substitution
+
+steps:
+# Build the dpkg_parser PAR file
+# this binary is used by the package manager rules
+# to download debian package lists and debian packages
+- name: gcr.io/cloud-builders/bazel
+  args: [
+    '--output_base', '/workspace',
+    'build', '//package_manager:dpkg_parser.par',
+    # TODO(r2d4): Remove once PAR compilation runs properly inside
+    # the Bazel sandbox on cloudbuild.
+    '--strategy', 'PythonCompile=standalone'
+  ]
+
+# Upload the dpkg_parser PAR file to a GCS bucket
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    'cp',
+    'bazel-bin/package_manager/dpkg_parser.par',
+    'gs://distroless/package_manager_tools/$COMMIT_SHA/dpkg_parser.par'
+  ]
+
+# We produce no Docker images.
+images: []

--- a/package_manager/dpkg.bzl
+++ b/package_manager/dpkg.bzl
@@ -1,0 +1,65 @@
+def _dpkg_impl(repository_ctx):
+  repository_ctx.file("file/BUILD", """
+package(default_visibility = ["//visibility:public"])
+exports_files(["pkg.deb"])
+""")
+
+  args = [
+      repository_ctx.path(repository_ctx.attr._dpkg_parser),
+      "--packages-file", repository_ctx.path(repository_ctx.attr.source),
+      "--package-name", repository_ctx.name
+  ]
+
+  result = repository_ctx.execute(args)
+  if result.return_code:
+    fail("dpkg_parser command failed: %s (%s)" % (result.stderr, " ".join(args)))
+
+_dpkg = repository_rule(
+    _dpkg_impl,
+    attrs = {
+        "source": attr.label(
+            allow_single_file = True,
+        ),
+        "_dpkg_parser": attr.label(
+            executable = True,
+            default = Label("@dpkg_parser//file:dpkg_parser.par"),
+            cfg = "host",
+        ),
+    },
+)
+
+def _dpkg_src_impl(repository_ctx):
+  repository_ctx.file("file/BUILD", """
+package(default_visibility = ["//visibility:public"])
+exports_files(["Packages.json"])
+""")
+  args = [
+      repository_ctx.path(repository_ctx.attr._dpkg_parser),
+      "--download-and-extract-only=True",
+      "--mirror-url=" + repository_ctx.attr.url,
+      "--arch=" + repository_ctx.attr.arch, 
+      "--distro=" + repository_ctx.attr.distro
+  ]
+  result = repository_ctx.execute(args)
+  if result.return_code:
+    fail("dpkg_parser command failed: %s (%s)" % (result.stderr, " ".join(args)))
+
+_dpkg_src = repository_rule(
+    _dpkg_src_impl,
+    attrs = {
+        "url": attr.string(),
+        "arch": attr.string(),
+        "distro": attr.string(),
+        "_dpkg_parser": attr.label(
+            executable = True,
+            default = Label("@dpkg_parser//file:dpkg_parser.par"),
+            cfg = "host",
+        ),
+    },
+)
+
+def dpkg(**kwargs):
+  _dpkg(**kwargs)
+
+def dpkg_src(**kwargs):
+  _dpkg_src(**kwargs)

--- a/package_manager/dpkg_parser.py
+++ b/package_manager/dpkg_parser.py
@@ -1,0 +1,112 @@
+# Copyright 2017 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import gzip
+import io
+import urllib2
+import json
+
+
+from package_manager.parse_metadata import parse_package_metadata
+
+PACKAGES_FILE_NAME = "file/Packages.json"
+DEB_FILE_NAME = "file/pkg.deb"
+FILENAME_KEY = "Filename"
+
+parser = argparse.ArgumentParser(
+    description="Downloads a deb package from a package source file"
+)
+
+parser.add_argument("--packages-file", action='store',
+                    help='The file path of the Packages.gz file')
+parser.add_argument("--package-name", action='store',
+                    help='The name of the package to search for and download')
+
+parser.add_argument("--download-and-extract-only", action='store',
+                    help='If True, download Packages.gz and make urls absolute from mirror url')
+parser.add_argument("--mirror-url", action='store',
+                    help='The base url for the package list mirror')
+parser.add_argument("--arch", action='store',
+                    help='The target architecture for the package list')
+parser.add_argument("--distro", action='store',
+                    help='The target distribution for the package list')
+
+def main():
+    """ A tool for downloading debian packages and package metadata """
+    args = parser.parse_args()
+    if args.download_and_extract_only:
+        download_package_list(args.mirror_url, args.distro, args.arch)
+    else:
+        download_dpkg(args.packages_file, args.package_name)
+
+
+def download_dpkg(packages_file, package_name):
+    """ Using an unzipped, json package file with full urls,
+     downloads a .deb package
+
+    Uses the 'Filename' key to download the .deb package
+    """
+    with open(packages_file, 'rb') as f:
+        metadata = json.load(f)
+    pkg = metadata[package_name]
+    buf = urllib2.urlopen(pkg[FILENAME_KEY])
+    with open(DEB_FILE_NAME, 'w') as f:
+        f.write(buf.read())
+
+
+def download_package_list(mirror_url, distro, arch):
+    """Downloads a debian package list, expands the relative urls,
+    and saves the metadata as a json file
+
+    A debian package list is a gzipped, newline delimited, colon separated
+    file with metadata about all the packages available in that repository.
+    Multiline keys are indented with spaces.
+
+    An example package looks like:
+
+Package: newmail
+Version: 0.5-2
+Installed-Size: 76
+Maintainer: Martin Schulze <joey@debian.org>
+Architecture: amd64
+Depends: libc6 (>= 2.7-1)
+Description: Notificator for incoming mail
+Homepage: http://www.infodrom.org/projects/newmail/
+Description-md5: 49b0168ce625e668ce3031036ad2f541
+Tag: interface::commandline, mail::notification, role::program,
+ scope::utility, works-with::mail
+Section: mail
+Priority: optional
+Filename: pool/main/n/newmail/newmail_0.5-2_amd64.deb
+Size: 14154
+MD5sum: 5cd31aab55877339145517fb6d5646cb
+SHA1: 869934a25a8bb3def0f17fef9221bed2d3a460f9
+SHA256: 52ec3ac93cf8ba038fbcefe1e78f26ca1d59356cdc95e60f987c3f52b3f5e7ef
+
+    """
+    url = "%s/debian/dists/%s/main/binary-%s/Packages.gz" % (
+        mirror_url,
+        distro,
+        arch
+    )
+    buf = urllib2.urlopen(url)
+    f = gzip.GzipFile(fileobj=io.BytesIO(buf.read()))
+    data = f.read()
+    metadata = parse_package_metadata(data, mirror_url)
+    with open(PACKAGES_FILE_NAME, 'w') as f:
+        json.dump(metadata, f)
+
+if __name__ == "__main__":
+    main()

--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -1,0 +1,9 @@
+load(":dpkg.bzl", "dpkg", "dpkg_src")
+
+def package_manager_repositories():
+  native.http_file(
+      name = "dpkg_parser",
+      url = ('https://storage.googleapis.com/distroless/package_manager_tools/0.1/dpkg_parser.par'),
+      executable = True,
+      sha256 = "5fc18fbd571996010409162fe0124cd308b85a9610f1ceb4f8b3048f312b9cd0",
+  )

--- a/package_manager/parse_metadata.py
+++ b/package_manager/parse_metadata.py
@@ -1,0 +1,58 @@
+# Copyright 2017 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+INDEX_KEY = "Package"
+FILENAME_KEY = "Filename"
+SEPARATOR = ":"
+
+def parse_package_metadata(data, mirror_url):
+    """ Takes a debian package list, changes the relative urls to absolute urls,
+    and saves the resulting metadata as a json file """
+    raw_entries = [line.rstrip() for line in data.splitlines()]
+    parsed_entries = {}
+    current_key = None
+    current_entry = {}
+
+    for line in raw_entries:
+        if line:
+            # If the line starts with indentation,
+            # it is a continuation of the previous key
+            if re.match(r'\s', line):
+                if current_entry is None or current_key is None:
+                    raise Exception("Found incorrect indention on line:" + line)
+                current_entry[current_key] += line.strip()
+            elif SEPARATOR in line:
+                (key, value) = line.split(SEPARATOR, 1)
+                current_key = key.strip()
+                if current_key in current_entry:
+                    raise Exception("Duplicate key for package metadata:"
+                                    + current_key + "\n" + current_entry)
+                current_entry[current_key] = value.strip()
+            else:
+                raise Exception("Valid line, but no delimiter or indentation:"
+                                + line)
+        else:
+            if current_entry:
+                parsed_entries[current_entry[INDEX_KEY]] = current_entry
+            current_entry = {}
+            current_key = None
+    if current_entry:
+        parsed_entries[current_entry[INDEX_KEY]] = current_entry
+    # The Filename Key is a relative url pointing to the .deb package
+    # Here, we're rewriting the metadata with the absolute urls,
+    # which is a concatenation of the mirror + '/debian/' + relative_path
+    for pkg_data in parsed_entries.itervalues():
+        pkg_data[FILENAME_KEY] = mirror_url + "/debian/" + pkg_data[FILENAME_KEY]
+    return parsed_entries

--- a/package_manager/parse_metadata_test.py
+++ b/package_manager/parse_metadata_test.py
@@ -1,0 +1,42 @@
+import unittest
+import os
+
+from package_manager.parse_metadata import parse_package_metadata
+
+class TestParseMetadata(unittest.TestCase):
+
+
+    def setUp(self):
+        current_dir = os.path.dirname(__file__)
+        filename = os.path.join(current_dir, 'testdata', 'Packages.txt')
+        with open(filename) as f:
+            data = f.read()
+        self.data = data
+        self.mirror_url = "http://debian.org"
+        self.metadata = parse_package_metadata(self.data, self.mirror_url)
+
+    def test_url_rewrite(self):
+        """ Relative url should have gotten rewritten with absolute url """
+        self.assertEqual(
+            self.metadata["libnewlib-dev"]["Filename"],
+            self.mirror_url + "/debian/" + "pool/main/n/newlib/libnewlib-dev_2.1.0+git20140818.1a8323b-2_all.deb")
+
+    def test_get_all_packages(self):
+        """ Parser should identify all packages """
+        expected_packages = ["libnewlib-dev",
+                             "libnewlib-doc",
+                             "newlib-source",
+                             "newmail",
+                             "zzuf",]
+        for pkg in expected_packages:
+            self.assertEqual(expected_packages.sort(), self.metadata.keys().sort())
+
+    def test_multiline_key(self):
+        """ Multiline keys should be properly parsed """
+        expected_tags = "interface::commandline, mail::notification, role::program,scope::utility, works-with::mail"
+        self.assertEqual(expected_tags, self.metadata["newmail"]["Tag"])
+
+if __name__ == '__main__':
+
+
+    unittest.main()

--- a/package_manager/testdata/Packages.txt
+++ b/package_manager/testdata/Packages.txt
@@ -1,0 +1,93 @@
+Package: libnewlib-dev
+Source: newlib
+Version: 2.1.0+git20140818.1a8323b-2
+Installed-Size: 655
+Maintainer: Agustin Henze <tin@debian.org>
+Architecture: all
+Replaces: libnewlib0
+Suggests: libnewlib-arm-none-eabi, gcc-arm-none-eabi
+Breaks: libnewlib0
+Description: C library and math library intended for use on embedded systems
+Homepage: https://sourceware.org/newlib/
+Description-md5: 162c7aade6589c92a4fbbfc3569b799e
+Tag: devel::library, role::devel-lib
+Section: libdevel
+Priority: extra
+Filename: pool/main/n/newlib/libnewlib-dev_2.1.0+git20140818.1a8323b-2_all.deb
+Size: 224488
+MD5sum: d23fb1e09ff74af446a72454831b8a99
+SHA1: 451ef34577a9a98ea30ec0890507d3dce97ac3fc
+SHA256: dc810570e557bdcb3570c715b13e7521e153f741cf88a62443c6d6101025b3b5
+
+Package: libnewlib-doc
+Source: newlib
+Version: 2.1.0+git20140818.1a8323b-2
+Installed-Size: 2008
+Maintainer: Agustin Henze <tin@debian.org>
+Architecture: all
+Recommends: libnewlib-dev
+Description: C library and math library intended for use on embedded systems (doc)
+Homepage: https://sourceware.org/newlib/
+Description-md5: 40948aff3525e14c614fec3d16fcd682
+Section: doc
+Priority: extra
+Filename: pool/main/n/newlib/libnewlib-doc_2.1.0+git20140818.1a8323b-2_all.deb
+Size: 286846
+MD5sum: 4276af40ba4721199371ec214cf7ee56
+SHA1: 0769fc9fbba41e2fb4d6913c3ddf88db8f0f628b
+SHA256: 80f29946dec5802a9be116a5d30d43362318bde9e7dce722413a12010e9bcb91
+
+Package: newlib-source
+Source: newlib
+Version: 2.1.0+git20140818.1a8323b-2
+Installed-Size: 4637
+Maintainer: Agustin Henze <tin@debian.org>
+Architecture: all
+Recommends: xz-utils
+Description: C library and math library intended for use on embedded systems (source)
+Homepage: https://sourceware.org/newlib/
+Description-md5: 1a43d500b6359fa0802bf4b2d3bbe002
+Tag: role::source
+Section: devel
+Priority: extra
+Filename: pool/main/n/newlib/newlib-source_2.1.0+git20140818.1a8323b-2_all.deb
+Size: 4687602
+MD5sum: ee01527e5438eb1f5710ee579254e5aa
+SHA1: b6977e516115f26d7db9392579b2273e5efc25b9
+SHA256: 7fb8ae95b43bdc0c8398714b130e8ba2a21fca4b31cd94642f904c27c0300f2b
+
+Package: newmail
+Version: 0.5-2
+Installed-Size: 76
+Maintainer: Martin Schulze <joey@debian.org>
+Architecture: amd64
+Depends: libc6 (>= 2.7-1)
+Description: Notificator for incoming mail
+Homepage: http://www.infodrom.org/projects/newmail/
+Description-md5: 49b0168ce625e668ce3031036ad2f541
+Tag: interface::commandline, mail::notification, role::program,
+ scope::utility, works-with::mail
+Section: mail
+Priority: optional
+Filename: pool/main/n/newmail/newmail_0.5-2_amd64.deb
+Size: 14154
+MD5sum: 5cd31aab55877339145517fb6d5646cb
+SHA1: 869934a25a8bb3def0f17fef9221bed2d3a460f9
+SHA256: 52ec3ac93cf8ba038fbcefe1e78f26ca1d59356cdc95e60f987c3f52b3f5e7ef
+
+Package: zzuf
+Version: 0.13.svn20100215-4.1
+Installed-Size: 209
+Maintainer: Sam Hocevar <sho@debian.org>
+Architecture: amd64
+Depends: libc6 (>= 2.14)
+Description: transparent application fuzzer
+Description-md5: 27dbe1f74dc9503e917a86ba5a96a833
+Tag: implemented-in::c, role::program
+Section: devel
+Priority: optional
+Filename: pool/main/z/zzuf/zzuf_0.13.svn20100215-4.1_amd64.deb
+Size: 86174
+MD5sum: 0cf99b320ef14cdaead8dc98184242b6
+SHA1: 47b4e9b5def65974fb0e76355687977923946137
+SHA256: 6b063ba41ed2efc58931ebbd6ff668c522cb22c734597fa2409885eb9bd4fcd2

--- a/python2.7/BUILD
+++ b/python2.7/BUILD
@@ -7,10 +7,10 @@ docker_build(
     name = "python27",
     base = "//base:base",
     debs = [
-        "@zlib//file",
-        "@python27//file",
-        "@libpython27//file",
-        "@libpython27_stdlib//file",
+        "@zlib1g//file:pkg.deb",
+        "@python2.7-minimal//file:pkg.deb",
+        "@libpython2.7-minimal//file:pkg.deb",
+        "@libpython2.7-stdlib//file:pkg.deb",
     ],
     entrypoint = [
         "/usr/bin/python2.7",


### PR DESCRIPTION
These are bazel rules to help resolve remote locations of the .deb
dependencies in our images.

ref #7 

This is a first pass at adding rules that make the .deb resolution more user friendly and less fragile.  No need to resolve the URLs manually and hardcode into an http_rule.  I'm not sure how to really incorporate them in the WORKSPACE, but I imagined something like this in BUILD files.

```
load("//packages:deb_pkg.bzl", "deb_pkg")
load("//packages:deb_src.bzl", "deb_src")

deb_pkg(
    name = "openssl",
    pkg_name = "openssl",
    source = ":debian_jessie",
)

deb_src(
    name = "debian_jessie",
    arch = "amd64",
    distro = "jessie",
    mirror_url = "http://httpredir.debian.org",
)
```

then you can reference the debs in your docker_rule by 

```
docker_build(
    name = "base",
    base = ":with_tmp",
    debs = [
        ":openssl",
        ...
    ],
)
```

This could also the be the entrypoint for future deb rules like dependency resolution.  I probably need to add version checking and checksum verification to these rules also.

These are my first bazel rules so let me know if I'm on the right track :)
