### PR TITLE
Add an image that uses a basic libc call from go.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ workspace(name = "distroless")
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.4.0",
+    tag = "0.4.4",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")

--- a/base/BUILD
+++ b/base/BUILD
@@ -2,6 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("@io_bazel_rules_docker//docker/contrib:passwd.bzl", "passwd_file")
+load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
 
 # Create a default passwd_file rule.
 
@@ -40,8 +41,6 @@ docker_build(
         "@libstdcpp6//file",
     ],
 )
-
-load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
 
 structure_test(
     name = "base_test",

--- a/examples/nonroot/BUILD
+++ b/examples/nonroot/BUILD
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//docker/contrib:passwd.bzl", "passwd_file")
+load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+
+# Simple go program to print out the username and uid.
+go_binary(
+    name = "user",
+    srcs = ["testdata/user.go"],
+    visibility = ["//visibility:private"],
+)
+
+# Create a passwd file with a nonroot user and uid.
+passwd_file(
+    name = "nonroot",
+    info = "nonroot",
+    uid = 1002,
+    username = "nonroot",
+)
+
+# Include it in our image as a tar.
+docker_build(
+    name = "passwd_image",
+    base = "//base:base",
+    files = [":user"],
+    tars = [":nonroot.passwd.tar"],
+    user = "nonroot",
+    visibility = ["//visibility:private"],
+)
+
+# Test to verify this works :)
+structure_test(
+    name = "passwd_test",
+    config = "testdata/user.yaml",
+    image = ":passwd_image",
+    visibility = ["//visibility:private"],
+)

--- a/examples/nonroot/testdata/user.go
+++ b/examples/nonroot/testdata/user.go
@@ -1,0 +1,30 @@
+// Copyright 2017 Google Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os/user"
+)
+
+func main() {
+	u, err := user.Current()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("User:", u.Name)
+	fmt.Println("Uid:", u.Uid)
+}

--- a/examples/nonroot/testdata/user.yaml
+++ b/examples/nonroot/testdata/user.yaml
@@ -1,0 +1,5 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: user
+    command: ["/user"]
+    expectedOutput: ['User: nonroot', 'Uid: 1002']


### PR DESCRIPTION
This test fails without /etc/passwd or glibc.