### PR TITLE
Refactor dpkg rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Follow these steps to get started:
 
 For full documentation on how to use bazel to generate Docker images, see the [bazelbuild/rules_docker](http://github.com/bazelbuild/rules_docker) repository.
 
+For documentation and examples on how to use the bazel package manager rules, see [./package_manager](./package_manager)
+
 Examples can be found in this repository in the [examples](examples/) directory.
 
 ## Examples

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,7 @@ load(
     "//package_manager:package_manager.bzl",
     "package_manager_repositories",
     "dpkg_src",
-    "dpkg",
+    "dpkg_list",
 )
 
 package_manager_repositories()
@@ -23,73 +23,43 @@ dpkg_src(
     name = "debian_jessie",
     arch = "amd64",
     distro = "jessie",
-    url = "http://deb.debian.org",
+    sha256 = "8ff5e7a54d4e75bbbcd2f43ebc7cb4a082fbc5493bc9fb2dcdaaeacba6e76dee",
+    snapshot = "20170701T034145Z",
+    url = "http://snapshot.debian.org/archive",
 )
 
 dpkg_src(
     name = "debian_jessie_backports",
     arch = "amd64",
     distro = "jessie-backports",
-    url = "http://deb.debian.org",
+    sha256 = "2a493443581bdb4be071359f7fb62122741f233d3596545d88239a4e4ec445e8",
+    snapshot = "20170701T034145Z",
+    url = "http://snapshot.debian.org/archive",
 )
 
-# For the glibc base image.
-dpkg(
-    name = "libc6",
-    source = "@debian_jessie//file:Packages.json",
-)
+dpkg_list(
+    name = "package_bundle",
+    packages = [
+        "libc6",
+        "ca-certificates",
+        "openssl",
+        "libssl1.0.0",
 
-dpkg(
-    name = "ca-certificates",
-    source = "@debian_jessie//file:Packages.json",
-)
+        #java
+        "zlib1g",
+        "libgcc1",
+        "libstdc++6",
+        "openjdk-8-jre-headless",
 
-dpkg(
-    name = "openssl",
-    source = "@debian_jessie//file:Packages.json",
-)
-
-dpkg(
-    name = "libssl1.0.0",
-    source = "@debian_jessie//file:Packages.json",
-)
-
-# For Java
-dpkg(
-    name = "zlib1g",
-    source = "@debian_jessie//file:Packages.json",
-)
-
-dpkg(
-    name = "openjdk-8-jre-headless",
-    source = "@debian_jessie_backports//file:Packages.json",
-)
-
-dpkg(
-    name = "libgcc1",
-    source = "@debian_jessie//file:Packages.json",
-)
-
-http_file(
-    name = "libstdcpp6",
-    sha256 = "f1509bbabd78e89c861de16931aec5988e1215649688fd4f8dfe1af875a7fbef",
-    url = "http://deb.debian.org/debian/pool/main/g/gcc-4.9/libstdc++6_4.9.2-10_amd64.deb",
-)
-
-# For Python
-dpkg(
-    name = "libpython2.7-minimal",
-    source = "@debian_jessie//file:Packages.json",
-)
-
-dpkg(
-    name = "python2.7-minimal",
-    source = "@debian_jessie//file:Packages.json",
-)
-
-dpkg(
-    name = "libpython2.7-stdlib",
-    source = "@debian_jessie//file:Packages.json",
+        #python
+        "libpython2.7-minimal",
+        "python2.7-minimal",
+        "libpython2.7-stdlib",
+    ],
+    sources = [
+        "@debian_jessie//file:Packages.json",
+        "@debian_jessie_backports//file:Packages.json",
+    ],
 )
 
 # For Jetty

--- a/base/BUILD
+++ b/base/BUILD
@@ -28,13 +28,15 @@ cacerts(
     name = "cacerts",
 )
 
+load("@package_bundle//file:packages.bzl", "packages")
+
 docker_build(
     name = "base",
     base = ":with_tmp",
     debs = [
-        "@libc6//file:pkg.deb",
-        "@libssl1.0.0//file:pkg.deb",
-        "@openssl//file:pkg.deb",
+        packages["libc6"],
+        packages["libssl1.0.0"],
+        packages["openssl"],
     ],
     tars = [
         ":base_passwd.passwd.tar",

--- a/cacerts/cacerts.bzl
+++ b/cacerts/cacerts.bzl
@@ -6,10 +6,12 @@ def _impl(ctx):
             inputs = [ctx.executable._extract, ctx.file.deb],
             outputs = [ctx.outputs.out])
 
+load("@package_bundle//file:packages.bzl", "packages")
+
 cacerts = rule(
     attrs = {
         "deb": attr.label(
-            default = Label("@ca-certificates//file:pkg.deb"),
+            default = Label(packages["ca-certificates"]),
             allow_files = [".deb"],
             single_file = True,
         ),

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -1,13 +1,14 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@package_bundle//file:packages.bzl", "packages")
 
 # An intermediate image for Java and other "mostly statically" compiled languages
 docker_build(
     name = "cc",
     base = "//base:base",
     debs = [
-        "@libgcc1//file:pkg.deb",
-        "@libstdcpp6//file",
+        packages["libgcc1"],
+        packages["libstdc++6"],
     ],
 )

--- a/java/BUILD
+++ b/java/BUILD
@@ -1,13 +1,14 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@package_bundle//file:packages.bzl", "packages")
 
 docker_build(
     name = "java8",
     base = "//cc:cc",
     debs = [
-        "@zlib1g//file:pkg.deb",
-        "@openjdk-8-jre-headless//file:pkg.deb",
+        packages["zlib1g"],
+        packages["openjdk-8-jre-headless"],
     ],
     entrypoint = [
         "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",

--- a/package_manager/BUILD
+++ b/package_manager/BUILD
@@ -5,12 +5,20 @@ par_binary(
     srcs = glob(["**/*.py"]),
     main = "dpkg_parser.py",
     visibility = ["//visibility:public"],
-    deps = [":parse_metadata"],
+    deps = [
+        ":parse_metadata",
+        ":util",
+    ],
 )
 
 py_library(
     name = "parse_metadata",
     srcs = ["parse_metadata.py"],
+)
+
+py_library(
+    name = "util",
+    srcs = ["util.py"],
 )
 
 py_test(
@@ -19,4 +27,12 @@ py_test(
     srcs = ["parse_metadata_test.py"],
     data = ["testdata/Packages.txt"],
     deps = [":parse_metadata"],
+)
+
+py_test(
+    name = "util_test",
+    size = "small",
+    srcs = ["util_test.py"],
+    data = ["testdata/checksum.txt"],
+    deps = [":util"],
 )

--- a/package_manager/README.md
+++ b/package_manager/README.md
@@ -1,0 +1,172 @@
+# Examples
+
+### **Downloading minimal python library packages from a snapshot of `debian jessie`**.
+
+`dpkg_src` and `dpkg_list` are repository rules, and therefore made to be used in the `WORKSPACE`.
+
+First, set up the package source with `dpkg_src` rule.  This example uses a snapshot of debian jessie from July 1st 2017.  The rule outputs a `file:Packages.json` which contains a parsed and formatted `Packages.gz` for `dpkg_list` to consume.
+
+```python
+dpkg_src(
+    name = "debian_jessie",
+    arch = "amd64",
+    distro = "jessie",
+    sha256 = "8ff5e7a54d4e75bbbcd2f43ebc7cb4a082fbc5493bc9fb2dcdaaeacba6e76dee",
+    snapshot = "20170701T034145Z",
+    url = "http://snapshot.debian.org/archive",
+)
+```
+
+You can now reference this `dpkg_src` rule when downloading packages in the `dpkg_list` rule.  The `dpkg_src` rule will output a `packages` map in `file:packages.bzl` for you to access the `.deb` artifacts. 
+
+```python
+dpkg_list(
+    name = "package_bundle",
+    packages = [
+        "libpython2.7-minimal",
+        "python2.7-minimal",
+        "libpython2.7-stdlib",
+        "zlib1g",
+    ],
+    sources = [
+        "@debian_jessie//file:Packages.json",
+    ],
+)
+```
+
+Finally, in a `BUILD` file, you can access the `.deb` files for rules that might require them.  We reference the package map from the previous `dpkg_list` rule and access the packages.  
+
+```python
+load("@package_bundle//file:packages.bzl", "packages")
+
+docker_build(
+    name = "python27",
+    base = "//base:base",
+    debs = [
+        packages["zlib1g"],
+        packages["python2.7-minimal"],
+        packages["libpython2.7-minimal"],
+        packages["libpython2.7-stdlib"],
+    ],
+    entrypoint = [
+        "/usr/bin/python2.7",
+    ],
+    symlinks = {
+        "/usr/bin/python": "/usr/bin/python2.7",
+    },
+)
+```
+
+# Reference
+
+## dpkg_src
+
+```python
+dpkg_src(name, url, arch, distro, snapshot, sha256, dpkg_parser)
+```
+
+A rule that downloads a Packages.gz snapshot file and parses it into a readable format for `dpkg_list`.  It currently only supports snapshots from [http://snapshot.debian.org/](http://snapshot.debian.org/).  You can find out more about the format and sources available there.  
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <p><code>name, required</code></p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>url</code></td>
+      <td>
+        <p><code>the base url of the package repository, required</code></p>
+        <p>The url that hosts snapshots of Packages.gz files.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>arch</code></td>
+      <td>
+        <p><code>the target package architecture, required</code></p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>distro</code></td>
+      <td>
+        <p><code>the name of the package distribution, required</code></p>
+        <p>Examples: wheezy, jessie, jessie-backports, etc.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>snapshot</code></td>
+      <td>
+        <p><code>the snapshot date of the Packages.gz, required</code></p>
+        <p>Format: YYYYMMDDTHHMMSSZ.  You can query a list of possible dates for snapshot.debian.org at <a href=
+        'http://snapshot.debian.org/archive/debian/?year=2009;month=10'>http://snapshot.debian.org/archive/debian/?year=2009;month=10</a>
+      </td>
+    </tr>
+    <tr>
+      <td><code>sha256</code></td>
+      <td>
+        <p><code>the sha256 of the Packages.gz file, required</code></p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>dpkg_parser</code></td>
+      <td>
+        <p><code>A binary that translates a Packages.gz file into a format readable by dpkg_list, required</code></p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## dpkg_list
+
+```python
+dpkg_list(name, packages, sources)
+```
+
+A rule that downloads `.deb` packages and makes them available in the WORKSPACE.
+
+For a `dpkg_list` rule named `package_bundle`, packages can be used by loading `load("@package_bundle//file:packages.bzl", "packages")` into your `BUILD` file, then referencing the package with `packages['packagename']`
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <p><code>name, required</code></p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>packages</code></td>
+      <td>
+        <p><code>a string array of packages to download, required</code></p>
+        <p>The url that hosts snapshots of Packages.gz files.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>sources</code></td>
+      <td>
+        <p><code>a list of outputs from dpkg_src, required</code></p>
+        <p>A list of snapshot sources that will be checked when downloading the package.  If a package is present in multiple sources, the first source in the list will be chosen.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -5,5 +5,5 @@ def package_manager_repositories():
       name = "dpkg_parser",
       url = ('https://storage.googleapis.com/distroless/package_manager_tools/v0.3/dpkg_parser.par'),
       executable = True,
-      sha256 = "41683aa3e3202e3ca2a5d13e84e03853414f7eaa1a87f9313d55ec4b35f8c31c",
+      sha256 = "89862b3622a0768f6871675cb3fc05a64ad960b3c318a047a81e9e8bb17ce1f8",
   )

--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -1,9 +1,9 @@
-load(":dpkg.bzl", "dpkg", "dpkg_src")
+load(":dpkg.bzl", "dpkg_list", "dpkg_src")
 
 def package_manager_repositories():
   native.http_file(
       name = "dpkg_parser",
-      url = ('https://storage.googleapis.com/distroless/package_manager_tools/0.1/dpkg_parser.par'),
+      url = ('https://storage.googleapis.com/distroless/package_manager_tools/v0.3/dpkg_parser.par'),
       executable = True,
-      sha256 = "5fc18fbd571996010409162fe0124cd308b85a9610f1ceb4f8b3048f312b9cd0",
+      sha256 = "41683aa3e3202e3ca2a5d13e84e03853414f7eaa1a87f9313d55ec4b35f8c31c",
   )

--- a/package_manager/parse_metadata.py
+++ b/package_manager/parse_metadata.py
@@ -17,7 +17,7 @@ INDEX_KEY = "Package"
 FILENAME_KEY = "Filename"
 SEPARATOR = ":"
 
-def parse_package_metadata(data, mirror_url):
+def parse_package_metadata(data, mirror_url, snapshot):
     """ Takes a debian package list, changes the relative urls to absolute urls,
     and saves the resulting metadata as a json file """
     raw_entries = [line.rstrip() for line in data.splitlines()]
@@ -54,5 +54,5 @@ def parse_package_metadata(data, mirror_url):
     # Here, we're rewriting the metadata with the absolute urls,
     # which is a concatenation of the mirror + '/debian/' + relative_path
     for pkg_data in parsed_entries.itervalues():
-        pkg_data[FILENAME_KEY] = mirror_url + "/debian/" + pkg_data[FILENAME_KEY]
+        pkg_data[FILENAME_KEY] = mirror_url + "/debian/" + snapshot + "/" + pkg_data[FILENAME_KEY]
     return parsed_entries

--- a/package_manager/parse_metadata_test.py
+++ b/package_manager/parse_metadata_test.py
@@ -5,7 +5,6 @@ from package_manager.parse_metadata import parse_package_metadata
 
 class TestParseMetadata(unittest.TestCase):
 
-
     def setUp(self):
         current_dir = os.path.dirname(__file__)
         filename = os.path.join(current_dir, 'testdata', 'Packages.txt')
@@ -13,13 +12,13 @@ class TestParseMetadata(unittest.TestCase):
             data = f.read()
         self.data = data
         self.mirror_url = "http://debian.org"
-        self.metadata = parse_package_metadata(self.data, self.mirror_url)
+        self.metadata = parse_package_metadata(self.data, self.mirror_url, "20170701")
 
     def test_url_rewrite(self):
         """ Relative url should have gotten rewritten with absolute url """
         self.assertEqual(
             self.metadata["libnewlib-dev"]["Filename"],
-            self.mirror_url + "/debian/" + "pool/main/n/newlib/libnewlib-dev_2.1.0+git20140818.1a8323b-2_all.deb")
+            self.mirror_url + "/debian/20170701/" + "pool/main/n/newlib/libnewlib-dev_2.1.0+git20140818.1a8323b-2_all.deb")
 
     def test_get_all_packages(self):
         """ Parser should identify all packages """

--- a/package_manager/testdata/checksum.txt
+++ b/package_manager/testdata/checksum.txt
@@ -1,0 +1,1 @@
+file for testings sha256

--- a/package_manager/util.py
+++ b/package_manager/util.py
@@ -1,0 +1,15 @@
+import hashlib
+import base64
+
+def sha256_checksum(filename, block_size=65536):
+    sha256 = hashlib.sha256()
+    with open(filename, 'rb') as f:
+        for block in iter(lambda: f.read(block_size), b''):
+            sha256.update(block)
+    return sha256.hexdigest()
+
+def package_to_rule(workspace_name, s):
+    return  "@" + workspace_name + "//file:" + encode_package_name(s)
+
+def encode_package_name(s):
+    return base64.urlsafe_b64encode(s) + ".deb"

--- a/package_manager/util_test.py
+++ b/package_manager/util_test.py
@@ -1,0 +1,10 @@
+import unittest
+from package_manager import util
+
+CHECKSUM_TXT = "1915adb697103d42655711e7b00a7dbe398a33d7719d6370c01001273010d069"
+
+class TestUtil(unittest.TestCase):
+
+    def test_sha256(self):
+        actual = util.sha256_checksum("checksum_txt")
+        self.assertEqual(CHECKSUM_TXT, actual)

--- a/python2.7/BUILD
+++ b/python2.7/BUILD
@@ -2,15 +2,16 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+load("@package_bundle//file:packages.bzl", "packages")
 
 docker_build(
     name = "python27",
     base = "//base:base",
     debs = [
-        "@zlib1g//file:pkg.deb",
-        "@python2.7-minimal//file:pkg.deb",
-        "@libpython2.7-minimal//file:pkg.deb",
-        "@libpython2.7-stdlib//file:pkg.deb",
+        packages["zlib1g"],
+        packages["python2.7-minimal"],
+        packages["libpython2.7-minimal"],
+        packages["libpython2.7-stdlib"],
     ],
     entrypoint = [
         "/usr/bin/python2.7",


### PR DESCRIPTION
* Allows multiple sources on the dpkg() rule
Sources will be tried in the order they appear.  For different priority, split up your package bundles into different dpkg rules.

* Automatically renames packages that are not valid bazel rule names.
Prints out a warning with instructions on how to reference the resulting deb.  The best solution I can think of here is to eventually output a tarball of deb packages.  Then, the output wouldn't have to be the individual deb files (which for some packages won't be able to be referenced by bazel labels).

* Allows multiple packages to be part of the same dpkg() rule

* Bumps version of dpkg_parser.par to v0.2

Fixes https://github.com/GoogleCloudPlatform/distroless/issues/70
Partially addresses  #68 

