### PR TITLE
Move test commands to script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,7 @@ install:
   - pip install pylint
 
 script:
-  - bazel clean && bazel build //...
-  - bazel test --test_output=errors //...
-  - ./buildifier.sh
-  - find . -iname "*.py" |xargs pylint --disable=R,C
+  - ./test.sh
 
 notifications:
   email: false

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2017 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Bazel build and test
+bazel clean
+bazel build //...
+bazel test --test_output=errors //...
+
+# Linting
+./buildifier.sh
+find . -name "*.py" |xargs pylint --disable=R,C


### PR DESCRIPTION
Makes it easier to run the full travis suite locally.

Added the Google copyright header to this file since its in the GoogleCloudPlatform org.  Is that right @dlorenc?