### PR TITLE
Add the standard /usr/bin/java symlink.

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -10,11 +10,14 @@ docker_build(
         "@openjdk-8-jre-headless//file:pkg.deb",
     ],
     entrypoint = [
-        "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
+        "/usr/bin/java",
         "-jar",
         # We expect users to use:
         # cmd = ["/path/to/deploy.jar", "--option1", ...]
     ],
+    symlinks = {
+        "/usr/bin/java": "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
+    },
 )
 
 load("@runtimes_common//structure_tests:tests.bzl", "structure_test")


### PR DESCRIPTION
This removes some of the guesswork about where the Java binary is in derivative layers.