### PR TITLE
Update the distroless examples to utilize the new contrib image rules.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -94,7 +94,7 @@ http_file(
 # Docker rules.
 git_repository(
     name = "io_bazel_rules_docker",
-    commit = "79aa5de0eb7348876316c537f7cec26bae02cfab",
+    commit = "b65749d4ae364986ace9ce15d29708b266921d80",
     remote = "https://github.com/bazelbuild/rules_docker.git",
 )
 
@@ -104,6 +104,30 @@ load(
 )
 
 docker_repositories()
+
+# Have the py_image dependencies for testing.
+load(
+    "@io_bazel_rules_docker//docker/contrib/python:image.bzl",
+    _py_image_repos = "repositories",
+)
+
+_py_image_repos()
+
+# Have the java_image dependencies for testing.
+load(
+    "@io_bazel_rules_docker//docker/contrib/java:image.bzl",
+    _java_image_repos = "repositories",
+)
+
+_java_image_repos()
+
+# Have the go_image dependencies for testing.
+load(
+    "@io_bazel_rules_docker//docker/contrib/go:image.bzl",
+    _go_image_repos = "repositories",
+)
+
+_go_image_repos()
 
 git_repository(
     name = "runtimes_common",

--- a/examples/go/BUILD
+++ b/examples/go/BUILD
@@ -1,19 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
-
 # Go boilerplate
-load("@io_bazel_rules_go//go:def.bzl", "go_binary")
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//docker/contrib/go:image.bzl", "go_image")
 
-go_binary(
-    name = "hello_go",
-    srcs = ["main.go"],
-)
-
-docker_build(
+go_image(
     name = "go_example",
+    srcs = ["main.go"],
     base = "//base:base",
-    cmd = ["./hello_go"],
-    files = [":hello_go"],
 )

--- a/examples/java/BUILD
+++ b/examples/java/BUILD
@@ -1,18 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//docker/contrib/java:image.bzl", "java_image")
 
-java_binary(
-    name = "HelloJava",
-    srcs = ["HelloJava.java"],
-    main_class = "examples.HelloJava",
-)
-
-docker_build(
+java_image(
     name = "hello",
+    srcs = ["HelloJava.java"],
     base = "//java:java8",
-    cmd = ["/HelloJava_deploy.jar"],
-    files = [":HelloJava_deploy.jar"],
+    main_class = "examples.HelloJava",
 )
 
 load("@runtimes_common//structure_tests:tests.bzl", "structure_test")

--- a/examples/java/testdata/hello.yaml
+++ b/examples/java/testdata/hello.yaml
@@ -1,5 +1,5 @@
 schemaVersion: "1.0.0"
 commandTests:
   - name: hello
-    command: ["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java", "-jar", "HelloJava_deploy.jar"]
+    command: ['/usr/bin/java', '-cp', '/app/examples/java/hello.binary.jar', 'examples.HelloJava']
     expectedOutput: ['Hello world']

--- a/examples/nonroot/BUILD
+++ b/examples/nonroot/BUILD
@@ -1,14 +1,7 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@io_bazel_rules_docker//docker/contrib/go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("@io_bazel_rules_docker//docker/contrib:passwd.bzl", "passwd_file")
 load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
-
-# Simple go program to print out the username and uid.
-go_binary(
-    name = "user",
-    srcs = ["testdata/user.go"],
-    visibility = ["//visibility:private"],
-)
 
 # Create a passwd file with a nonroot user and uid.
 passwd_file(
@@ -22,9 +15,16 @@ passwd_file(
 docker_build(
     name = "passwd_image",
     base = "//base:base",
-    files = [":user"],
     tars = [":nonroot.passwd.tar"],
     user = "nonroot",
+    visibility = ["//visibility:private"],
+)
+
+# Simple go program to print out the username and uid.
+go_image(
+    name = "user",
+    srcs = ["testdata/user.go"],
+    base = ":passwd_image",
     visibility = ["//visibility:private"],
 )
 
@@ -32,6 +32,6 @@ docker_build(
 structure_test(
     name = "passwd_test",
     config = "testdata/user.yaml",
-    image = ":passwd_image",
+    image = ":user",
     visibility = ["//visibility:private"],
 )

--- a/examples/nonroot/testdata/user.yaml
+++ b/examples/nonroot/testdata/user.yaml
@@ -1,5 +1,5 @@
 schemaVersion: "1.0.0"
 commandTests:
   - name: user
-    command: ["/user"]
+    command: ['/app/examples/nonroot/user.binary.runfiles/distroless/examples/nonroot/user.binary']
     expectedOutput: ['User: nonroot', 'Uid: 1002']

--- a/examples/python2.7/BUILD
+++ b/examples/python2.7/BUILD
@@ -1,19 +1,16 @@
+load("@io_bazel_rules_docker//docker/contrib/python:image.bzl", "py_image")
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
-load("@subpar//:subpar.bzl", "par_binary")
 
-par_binary(
+py_image(
     name = "hello_py",
     srcs = ["hello.py"],
+    base = "//python2.7:python27",
     main = "hello.py",
 )
 
 # This example runs a python program that walks the filesystem under "/etc" and prints every filename.
 docker_build(
     name = "hello",
-    base = "//python2.7:python27",
-    cmd = [
-        "/hello_py.par",
-        "/etc",
-    ],
-    files = [":hello_py.par"],
+    base = ":hello_py",
+    cmd = ["/etc"],
 )


### PR DESCRIPTION
PoC that consumes the `foo_image` rules I'm adding in [this PR](https://github.com/bazelbuild/rules_docker/pull/98).