### PR TITLE
Make cacerts public.

### DIFF
--- a/cacerts/BUILD
+++ b/cacerts/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 sh_binary(
     name = "extract_certs",


### PR DESCRIPTION
I need this over in debian-docker.