### PR TITLE
Update runtimes_common repository

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -131,6 +131,6 @@ _go_image_repos()
 
 git_repository(
     name = "runtimes_common",
-    commit = "3d73b4fecbd18de77588ab5eef712d50f34f601e",
+    tag = "v0.1.0",
     remote = "https://github.com/GoogleCloudPlatform/runtimes-common.git",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -131,6 +131,6 @@ _go_image_repos()
 
 git_repository(
     name = "runtimes_common",
-    tag = "v0.1.0",
     remote = "https://github.com/GoogleCloudPlatform/runtimes-common.git",
+    tag = "v0.1.0",
 )


### PR DESCRIPTION
This is easier to reason about the current version used and to find it online than a commit hash.