### PR TITLE
Don't hardcode /debian in apt URLs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,7 +25,7 @@ dpkg_src(
     distro = "jessie",
     sha256 = "142cceae78a1343e66a0d27f1b142c406243d7940f626972c2c39ef71499ce61",
     snapshot = "20170821T035341Z",
-    url = "http://snapshot.debian.org/archive",
+    url = "http://snapshot.debian.org/archive/debian",
 )
 
 dpkg_src(
@@ -34,7 +34,7 @@ dpkg_src(
     distro = "jessie-backports",
     sha256 = "eba769f0a0bcaffbb82a8b61d4a9c8a0a3299d5111a68daeaf7e50cc0f76e0ab",
     snapshot = "20170821T035341Z",
-    url = "http://snapshot.debian.org/archive",
+    url = "http://snapshot.debian.org/archive/debian",
 )
 
 dpkg_list(

--- a/package_manager/dpkg_parser.py
+++ b/package_manager/dpkg_parser.py
@@ -121,7 +121,7 @@ SHA1: 869934a25a8bb3def0f17fef9221bed2d3a460f9
 SHA256: 52ec3ac93cf8ba038fbcefe1e78f26ca1d59356cdc95e60f987c3f52b3f5e7ef
 
     """
-    url = "%s/debian/%s/dists/%s/main/binary-%s/Packages.gz" % (
+    url = "%s/%s/dists/%s/main/binary-%s/Packages.gz" % (
         mirror_url,
         snapshot,
         distro,

--- a/package_manager/parse_metadata.py
+++ b/package_manager/parse_metadata.py
@@ -52,7 +52,10 @@ def parse_package_metadata(data, mirror_url, snapshot):
         parsed_entries[current_entry[INDEX_KEY]] = current_entry
     # The Filename Key is a relative url pointing to the .deb package
     # Here, we're rewriting the metadata with the absolute urls,
-    # which is a concatenation of the mirror + '/debian/' + relative_path
+    # which is a concatenation of the mirror (with '/debian' or equivalent)
+    # and relative_path
     for pkg_data in parsed_entries.itervalues():
-        pkg_data[FILENAME_KEY] = mirror_url + "/debian/" + snapshot + "/" + pkg_data[FILENAME_KEY]
+        pkg_data[FILENAME_KEY] = "/".join([mirror_url,
+                                           snapshot,
+                                           pkg_data[FILENAME_KEY]])
     return parsed_entries

--- a/package_manager/parse_metadata_test.py
+++ b/package_manager/parse_metadata_test.py
@@ -11,14 +11,14 @@ class TestParseMetadata(unittest.TestCase):
         with open(filename) as f:
             data = f.read()
         self.data = data
-        self.mirror_url = "http://debian.org"
+        self.mirror_url = "http://http.us.debian.org/debian"
         self.metadata = parse_package_metadata(self.data, self.mirror_url, "20170701")
 
     def test_url_rewrite(self):
         """ Relative url should have gotten rewritten with absolute url """
         self.assertEqual(
             self.metadata["libnewlib-dev"]["Filename"],
-            self.mirror_url + "/debian/20170701/" + "pool/main/n/newlib/libnewlib-dev_2.1.0+git20140818.1a8323b-2_all.deb")
+            self.mirror_url + "/20170701/" + "pool/main/n/newlib/libnewlib-dev_2.1.0+git20140818.1a8323b-2_all.deb")
 
     def test_get_all_packages(self):
         """ Parser should identify all packages """


### PR DESCRIPTION
This is required in order to support repositories like `debian-security` and `ubuntu`.  The base `/debian` path isn't invariant, it's meant to be a part of the repository URL.