### PR TITLE
added simple version capability to dpkg_parser

### DIFF
--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -3,7 +3,7 @@ load(":dpkg.bzl", "dpkg_list", "dpkg_src")
 def package_manager_repositories():
   native.http_file(
       name = "dpkg_parser",
-      url = ('https://storage.googleapis.com/distroless/package_manager_tools/v0.3/dpkg_parser.par'),
+      url = ('https://storage.googleapis.com/distroless/package_manager_tools/v0.4/dpkg_parser.par'),
       executable = True,
-      sha256 = "89862b3622a0768f6871675cb3fc05a64ad960b3c318a047a81e9e8bb17ce1f8",
+      sha256 = "45fac43b00173621f4fc6e65c923a2d33e798c9e94a248ec43fafcdf0b014f15",
   )


### PR DESCRIPTION
This PR adds simple version capability to dpkg_parser.py  With this PR, versions can now be specified using the syntax "package=<VERSION>":
    packages = [
        "libc6=VERSION",
        "libwsutil-dev=2.2.4+gcc3dc1b-1~bpo8+1",
        "ca-certificates", # old syntax is still preserved
],
The old syntax of just using the package name is still preserved and works as it did previously.

NOTE:  Currently the version specified much exactly match the version value in the Packages.gz file.