### PR TITLE
Add /etc/os-release file generation package rules

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -39,6 +39,7 @@ docker_build(
         ":base_passwd.passwd.tar",
         ":cacerts.tar",
         ":tmp.tar",
+        "@debian_jessie//file:os_release.tar",
     ],
 )
 

--- a/base/testdata/base.yaml
+++ b/base/testdata/base.yaml
@@ -12,6 +12,9 @@ fileExistenceTests:
 - name: passwd
   path: '/etc/passwd'
   shouldExist: true
+- name: etc-os-release
+  path: '/etc/os-release'
+  shouldExist: true
 - name: certs
   path: '/etc/ssl/certs/ca-certificates.crt'
   shouldExist: true

--- a/package_manager/dpkg.bzl
+++ b/package_manager/dpkg.bzl
@@ -34,7 +34,7 @@ _dpkg_list = repository_rule(
 def _dpkg_src_impl(repository_ctx):
   repository_ctx.file("file/BUILD", """
 package(default_visibility = ["//visibility:public"])
-exports_files(["Packages.json"])
+exports_files(["Packages.json", "os_release.tar"])
 """)
   args = [
       repository_ctx.path(repository_ctx.attr._dpkg_parser),

--- a/package_manager/dpkg_parser.py
+++ b/package_manager/dpkg_parser.py
@@ -23,8 +23,11 @@ from package_manager.parse_metadata import parse_package_metadata
 from package_manager import util
 
 OUT_FOLDER = "file"
+OS_RELEASE_PATH = "etc"
 PACKAGES_FILE_NAME = os.path.join(OUT_FOLDER,"Packages.json")
 PACKAGE_MAP_FILE_NAME = os.path.join(OUT_FOLDER,"packages.bzl")
+OS_RELEASE_FILE_NAME = os.path.join(OS_RELEASE_PATH, "os-release")
+OS_RELEASE_TAR_FILE_NAME = os.path.join(OUT_FOLDER, "os_release.tar")
 DEB_FILE_NAME = os.path.join(OUT_FOLDER,"pkg.deb")
 
 FILENAME_KEY = "Filename"
@@ -60,9 +63,9 @@ def main():
     args = parser.parse_args()
     if args.download_and_extract_only:
         download_package_list(args.mirror_url, args.distro, args.arch, args.snapshot, args.sha256)
+        util.build_os_release_tar(args.distro, OS_RELEASE_FILE_NAME, OS_RELEASE_PATH, OS_RELEASE_TAR_FILE_NAME)
     else:
         download_dpkg(args.package_files, args.packages, args.workspace_name)
-
 
 def download_dpkg(package_files, packages, workspace_name):
     """ Using an unzipped, json package file with full urls,

--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -3,7 +3,7 @@ load(":dpkg.bzl", "dpkg_list", "dpkg_src")
 def package_manager_repositories():
   native.http_file(
       name = "dpkg_parser",
-      url = ('https://storage.googleapis.com/distroless/package_manager_tools/v0.4/dpkg_parser.par'),
+      url = ('https://storage.googleapis.com/distroless/package_manager_tools/v0.5/dpkg_parser.par'),
       executable = True,
-      sha256 = "45fac43b00173621f4fc6e65c923a2d33e798c9e94a248ec43fafcdf0b014f15",
+      sha256 = "e008f56117eaf12c6a7e60c47901419fa84a458e4732387f04d2101bae5c7c95",
   )

--- a/package_manager/util.py
+++ b/package_manager/util.py
@@ -1,5 +1,8 @@
 import hashlib
 import base64
+import collections
+import tarfile
+import os
 
 def sha256_checksum(filename, block_size=65536):
     sha256 = hashlib.sha256()
@@ -13,3 +16,45 @@ def package_to_rule(workspace_name, s):
 
 def encode_package_name(s):
     return base64.urlsafe_b64encode(s) + ".deb"
+
+DEBIAN_RELEASES = {
+    "stretch": "9",
+    "jessie": "8",
+    "wheezy": "7",
+    "squeeze": "6.0",
+    "lenny": "5.0",
+    "etch": "4.0",
+    "sarge": "3.1",
+    "woody": "3.0",
+    "potato": "2.2",
+}
+
+def generate_os_release(distro, os_release_file):
+    """ Generates an /etc/os-release like file with information about the
+    package distribution.  VERSION and VERSION_ID are left unset if the package
+    source is from an unknown debian release.
+    """
+
+    os_release = collections.OrderedDict([
+        ("PRETTY_NAME", "Distroless"),
+        ("NAME", "Debian GNU/Linux"),
+        ("ID", "debian"),
+        ("VERSION_ID", ""),
+        ("VERSION", ""),
+        ("HOME_URL", "https://github.com/GoogleCloudPlatform/distroless"),
+        ("SUPPORT_URL", "https://github.com/GoogleCloudPlatform/distroless/blob/master/README.md"),
+        ("BUG_REPORT_URL", "https://github.com/GoogleCloudPlatform/distroless/issues/new"),
+    ])
+    if distro in DEBIAN_RELEASES:
+        os_release["VERSION_ID"] = DEBIAN_RELEASES[distro]
+        os_release["VERSION"] = '{0} {1} ({2})'.format(os_release["NAME"], os_release["VERSION_ID"], distro)
+    for k, val in os_release.items():
+        if val:
+            os_release_file.write('{0}=\"{1}\"\n'.format(k, val))
+
+def build_os_release_tar(distro, os_release_file, os_release_path, tar_file_name):
+    os.makedirs(os_release_path)
+    with open(os_release_file, 'w') as os_release:
+        generate_os_release(distro, os_release)
+    with tarfile.open(tar_file_name, "w") as tar:
+        tar.add(os_release_file)

--- a/package_manager/util_test.py
+++ b/package_manager/util_test.py
@@ -1,10 +1,59 @@
 import unittest
+import os
+import StringIO
 from package_manager import util
 
+
 CHECKSUM_TXT = "1915adb697103d42655711e7b00a7dbe398a33d7719d6370c01001273010d069"
+
+DEBIAN_JESSIE_OS_RELEASE = """PRETTY_NAME="Distroless"
+NAME="Debian GNU/Linux"
+ID="debian"
+VERSION_ID="8"
+VERSION="Debian GNU/Linux 8 (jessie)"
+HOME_URL="https://github.com/GoogleCloudPlatform/distroless"
+SUPPORT_URL="https://github.com/GoogleCloudPlatform/distroless/blob/master/README.md"
+BUG_REPORT_URL="https://github.com/GoogleCloudPlatform/distroless/issues/new"
+"""
+
+DEBIAN_STRETCH_OS_RELEASE = """PRETTY_NAME="Distroless"
+NAME="Debian GNU/Linux"
+ID="debian"
+VERSION_ID="9"
+VERSION="Debian GNU/Linux 9 (stretch)"
+HOME_URL="https://github.com/GoogleCloudPlatform/distroless"
+SUPPORT_URL="https://github.com/GoogleCloudPlatform/distroless/blob/master/README.md"
+BUG_REPORT_URL="https://github.com/GoogleCloudPlatform/distroless/issues/new"
+"""
+
+# VERSION and VERSION_ID aren't set on unknown distros
+DEBIAN_UNKNOWN_OS_RELEASE = """PRETTY_NAME="Distroless"
+NAME="Debian GNU/Linux"
+ID="debian"
+HOME_URL="https://github.com/GoogleCloudPlatform/distroless"
+SUPPORT_URL="https://github.com/GoogleCloudPlatform/distroless/blob/master/README.md"
+BUG_REPORT_URL="https://github.com/GoogleCloudPlatform/distroless/issues/new"
+"""
+
+osReleaseForDistro = {
+    "jessie": DEBIAN_JESSIE_OS_RELEASE,
+    "stretch": DEBIAN_STRETCH_OS_RELEASE,
+    "???": DEBIAN_UNKNOWN_OS_RELEASE,
+}
 
 class TestUtil(unittest.TestCase):
 
     def test_sha256(self):
-        actual = util.sha256_checksum("checksum_txt")
+        current_dir = os.path.dirname(__file__)
+        filename = os.path.join(current_dir, 'testdata', 'checksum.txt')
+        actual = util.sha256_checksum(filename)
         self.assertEqual(CHECKSUM_TXT, actual)
+
+    def test_generate_debian_os_release(self):
+        for distro in ["jessie", "stretch", "???"]:
+            output_file = StringIO.StringIO()
+            util.generate_os_release(distro, output_file)
+            self.assertEqual(osReleaseForDistro[distro], output_file.getvalue())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds another output file to the dpkg_src rule with os-release-like
metadata about the distribution

Add a structure test validation for /etc/os-release in the base image