### PR TITLE
Update rules_go version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ workspace(name = "distroless")
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.5.3",
+    tag = "0.5.5",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")


### PR DESCRIPTION
Version 0.5.5 contains a bugfix for dependency checksums.

see https://github.com/bazelbuild/rules_go/releases/tag/0.5.5