### PR TITLE
Add a rule to generate java cacerts files using a debian docker image.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,6 +126,7 @@ load(
 # Used to generate java ca certs.
 docker_pull(
     name = "debian8",
+    # From tag: 2017-09-11-115552
     digest = "sha256:6d381d0bf292e31291136cff03b3209eb40ef6342fb790483fa1b9d3af84ae46",
     registry = "gcr.io",
     repository = "google-appengine/debian8",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -120,6 +120,15 @@ git_repository(
 load(
     "@io_bazel_rules_docker//docker:docker.bzl",
     "docker_repositories",
+    "docker_pull",
+)
+
+# Used to generate java ca certs.
+docker_pull(
+    name = "debian8",
+    digest = "sha256:6d381d0bf292e31291136cff03b3209eb40ef6342fb790483fa1b9d3af84ae46",
+    registry = "gcr.io",
+    repository = "google-appengine/debian8",
 )
 
 docker_repositories()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -113,7 +113,7 @@ http_file(
 # Docker rules.
 git_repository(
     name = "io_bazel_rules_docker",
-    commit = "839a297d4e874216b4fd93f09dd35be5592dc10e",
+    commit = "cdd259b3ba67fd4ef814c88070a2ebc7bec28dc5",
     remote = "https://github.com/bazelbuild/rules_docker.git",
 )
 

--- a/cacerts/java.bzl
+++ b/cacerts/java.bzl
@@ -1,0 +1,71 @@
+# Copyright 2017 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rule for building and extracting java ca-certificates inside of a docker image."""
+
+def _impl(ctx):
+    # Strip off the '.tar'
+    image_name = ctx.attr._builder_image.label.name.split('.', 1)[0]
+    # docker_build rules always generate an image named 'bazel/$package:$name'.
+    builder_image_name = "bazel/%s:%s" % (ctx.attr._builder_image.label.package,
+                                          image_name)
+
+    # Generate a shell script to run the build.
+    build_contents = """\
+#!/bin/bash
+set -ex
+docker load -i {0}
+# Install the certs in the builder image.
+cid=$(docker run -d {1} sh -c "apt-get update && apt-get install -y -q ca-certificates-java")
+docker attach $cid
+
+# Copy out the certs as a tarball
+mkdir -p etc/ssl/certs/java
+docker cp $cid:/etc/ssl/certs/java/cacerts etc/ssl/certs/java/cacerts
+tar -cf {2} etc/
+
+# Cleanup
+docker rm $cid
+ """.format(ctx.file._builder_image.path,
+            builder_image_name,
+            ctx.outputs.out.path)
+    script = ctx.actions.declare_file("cacerts.build")
+    ctx.file_action(
+        output=script,
+        content=build_contents,
+    )
+
+    ctx.actions.run(
+        outputs=[ctx.outputs.out],
+        inputs=ctx.attr._builder_image.files.to_list() +
+        ctx.attr._builder_image.data_runfiles.files.to_list() + ctx.attr._builder_image.default_runfiles.files.to_list(),
+        executable=script,
+    )
+
+    return struct()
+
+cacerts_java = rule(
+    attrs = {
+        "_builder_image": attr.label(
+            default = Label("@debian8//image:image.tar"),
+            allow_files = True,
+            single_file = True,
+        ),
+    },
+    executable = False,
+    outputs = {
+        "out": "%{name}.tar",
+    },
+    implementation = _impl,
+)

--- a/java/BUILD
+++ b/java/BUILD
@@ -3,7 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("@package_bundle//file:packages.bzl", "packages")
 load("//cacerts:java.bzl", "cacerts_java")
-load("@io_bazel_rules_docker//docker/contrib/java:image.bzl", "java_image")
+load("@io_bazel_rules_docker//java:image.bzl", "java_image")
 
 cacerts_java(
     name = "cacerts_java",

--- a/java/BUILD
+++ b/java/BUILD
@@ -2,6 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("@package_bundle//file:packages.bzl", "packages")
+load("//cacerts:java.bzl", "cacerts_java")
+
+cacerts_java(
+    name = "cacerts_java.tar",
+)
 
 docker_build(
     name = "java8",
@@ -19,6 +24,7 @@ docker_build(
     symlinks = {
         "/usr/bin/java": "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
     },
+    tars = [":cacerts_java.tar"],
 )
 
 load("@runtimes_common//structure_tests:tests.bzl", "structure_test")

--- a/java/BUILD
+++ b/java/BUILD
@@ -3,9 +3,10 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("@package_bundle//file:packages.bzl", "packages")
 load("//cacerts:java.bzl", "cacerts_java")
+load("@io_bazel_rules_docker//docker/contrib/java:image.bzl", "java_image")
 
 cacerts_java(
-    name = "cacerts_java.tar",
+    name = "cacerts_java",
 )
 
 docker_build(
@@ -24,13 +25,26 @@ docker_build(
     symlinks = {
         "/usr/bin/java": "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
     },
-    tars = [":cacerts_java.tar"],
+    tars = [":cacerts_java"],
 )
 
 load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
 
 structure_test(
     name = "java8_test",
+    config = "testdata/java.yaml",
+    image = ":java8",
+)
+
+java_image(
+    name = "check_certs",
+    srcs = ["testdata/CheckCerts.java"],
+    base = "//java:java8",
+    main_class = "testdata.CheckCerts",
+)
+
+structure_test(
+    name = "check_certs_test",
     config = "testdata/java.yaml",
     image = ":java8",
 )

--- a/java/testdata/CheckCerts.java
+++ b/java/testdata/CheckCerts.java
@@ -1,0 +1,31 @@
+package testdata;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.cert.Certificate;
+import java.io.*;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+
+
+public class CheckCerts {
+    public static void main(String[] args) {
+        String https_url = "https://www.google.com/";
+        URL url;
+  
+        try {
+            url = new URL(https_url);
+            HttpsURLConnection con = (HttpsURLConnection)url.openConnection();
+            con.connect();
+
+            Certificate[] certs = con.getServerCertificates();
+            System.out.println("Successfully connected");
+
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+
+    }
+}

--- a/java/testdata/certs.yaml
+++ b/java/testdata/certs.yaml
@@ -1,0 +1,9 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: java
+    # This is a bit ugly because structure tests can't test the default entrypoint yet.
+    command: ["/usr/bin/java",
+              "-cp",
+              "/app/java//check_certs.binary.jar:/app/java//check_certs.binary",
+              "testdata.CheckCerts"]
+    expectedOutput: ['Successfully connected']

--- a/java/testdata/java.yaml
+++ b/java/testdata/java.yaml
@@ -3,3 +3,7 @@ commandTests:
   - name: java
     command: ["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java", "-version"]
     expectedError: ['openjdk version "1\.8.*"']
+fileExistenceTests:
+  - name: certs
+    path: "/etc/ssl/certs/java/cacerts"
+    shouldExist: true


### PR DESCRIPTION
This isn't ideal, but works.