### PR TITLE
Add libgomp1 to the C++ image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,10 +47,13 @@ dpkg_list(
         "netbase",
         "tzdata",
 
+        #c++
+        "libgcc1",
+        "libgomp1",
+        "libstdc++6",
+
         #java
         "zlib1g",
-        "libgcc1",
-        "libstdc++6",
         "openjdk-8-jre-headless",
 
         #python

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -9,6 +9,7 @@ load("@package_bundle//file:packages.bzl", "packages")
     base = "//base" + mode,
     debs = [
         packages["libgcc1"],
+        packages["libgomp1"],
         packages["libstdc++6"],
     ],
 ) for mode in [


### PR DESCRIPTION
This is required for C++ binaries compiled with -fopenmp.