### PR TITLE
Add packages_gz_url and package_prefix in the dpkg_src rule.

### DIFF
--- a/package_manager/README.md
+++ b/package_manager/README.md
@@ -17,6 +17,20 @@ dpkg_src(
 )
 ```
 
+You can also set up the package source using the full url for the `Packages.gz` file. The `package_prefix` is used to
+prepend to the value of `Filename` in the `Packages.gz` file. In the following example, if the value of `Filename` is
+`pool/jdk1.8/b/bazel/bazel_0.7.0_amd64.deb`, then the `.deb` artifact will later be downloaded from
+`http://storage.googleapis.com/bazel-apt/pool/jdk1.8/b/bazel/bazel_0.7.0_amd64.deb`.
+
+```python
+dpkg_src(
+    name = "bazel_apt",
+    packages_gz_url = "http://storage.googleapis.com/bazel-apt/dists/stable/jdk1.8/binary-amd64/Packages.gz",
+    package_prefix = "http://storage.googleapis.com/bazel-apt/",
+    sha256 = "0fc4c6988ebf24705cfab0050cb5ad58e5b2aeb0e8cfb8921898a1809042416c",
+)
+```
+
 You can now reference this `dpkg_src` rule when downloading packages in the `dpkg_list` rule.  The `dpkg_src` rule will output a `packages` map in `file:packages.bzl` for you to access the `.deb` artifacts. 
 
 ```python
@@ -62,10 +76,14 @@ docker_build(
 ## dpkg_src
 
 ```python
-dpkg_src(name, url, arch, distro, snapshot, sha256, dpkg_parser)
+dpkg_src(name, url, arch, distro, snapshot, packages_gz_url, package_prefix, sha256, dpkg_parser)
 ```
 
-A rule that downloads a Packages.gz snapshot file and parses it into a readable format for `dpkg_list`.  It currently only supports snapshots from [http://snapshot.debian.org/](http://snapshot.debian.org/).  You can find out more about the format and sources available there.  
+A rule that downloads a `Packages.gz` snapshot file and parses it into a readable format for `dpkg_list`.
+It supports snapshots from [http://snapshot.debian.org/](http://snapshot.debian.org/). (You can find out more about the format and sources available there.)
+It also supports retrieving `Packages.gz` file from a given full url.
+
+Either a set of {`url`, `arch`, `distro`, `snapshot`} or a set of {`packages_gz_url`, `package_prefix`} must be set.
 
 <table class="table table-condensed table-bordered table-params">
   <colgroup>
@@ -87,29 +105,41 @@ A rule that downloads a Packages.gz snapshot file and parses it into a readable 
     <tr>
       <td><code>url</code></td>
       <td>
-        <p><code>the base url of the package repository, required</code></p>
+        <p><code>the base url of the package repository</code></p>
         <p>The url that hosts snapshots of Packages.gz files.</p>
       </td>
     </tr>
     <tr>
       <td><code>arch</code></td>
       <td>
-        <p><code>the target package architecture, required</code></p>
+        <p><code>the target package architecture</code></p>
       </td>
     </tr>
     <tr>
       <td><code>distro</code></td>
       <td>
-        <p><code>the name of the package distribution, required</code></p>
+        <p><code>the name of the package distribution</code></p>
         <p>Examples: wheezy, jessie, jessie-backports, etc.</p>
       </td>
     </tr>
     <tr>
       <td><code>snapshot</code></td>
       <td>
-        <p><code>the snapshot date of the Packages.gz, required</code></p>
+        <p><code>the snapshot date of the Packages.gz</code></p>
         <p>Format: YYYYMMDDTHHMMSSZ.  You can query a list of possible dates for snapshot.debian.org at <a href=
         'http://snapshot.debian.org/archive/debian/?year=2009;month=10'>http://snapshot.debian.org/archive/debian/?year=2009;month=10</a>
+      </td>
+    </tr>
+    <tr>
+      <td><code>packages_gz_url</code></td>
+      <td>
+        <p><code>the full url for the Packages.gz file</code></p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>package_prefix</code></td>
+      <td>
+        <p><code>the prefix to prepend to the value of Filename in the Packages.gz file</code></p>
       </td>
     </tr>
     <tr>

--- a/package_manager/dpkg.bzl
+++ b/package_manager/dpkg.bzl
@@ -40,9 +40,11 @@ exports_files(["Packages.json", "os_release.tar"])
       repository_ctx.path(repository_ctx.attr._dpkg_parser),
       "--download-and-extract-only=True",
       "--mirror-url=" + repository_ctx.attr.url,
-      "--arch=" + repository_ctx.attr.arch, 
+      "--arch=" + repository_ctx.attr.arch,
       "--distro=" + repository_ctx.attr.distro,
       "--snapshot=" + repository_ctx.attr.snapshot,
+      "--packages-gz-url=" + repository_ctx.attr.packages_gz_url,
+      "--package-prefix=" + repository_ctx.attr.package_prefix,
       "--sha256=" + repository_ctx.attr.sha256,
   ]
 
@@ -57,6 +59,8 @@ _dpkg_src = repository_rule(
         "arch": attr.string(),
         "distro": attr.string(),
         "snapshot": attr.string(),
+        "packages_gz_url": attr.string(),
+        "package_prefix": attr.string(),
         "sha256": attr.string(),
         "_dpkg_parser": attr.label(
             executable = True,

--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -3,7 +3,7 @@ load(":dpkg.bzl", "dpkg_list", "dpkg_src")
 def package_manager_repositories():
   native.http_file(
       name = "dpkg_parser",
-      url = ('https://storage.googleapis.com/distroless/package_manager_tools/v0.5/dpkg_parser.par'),
+      url = ('https://storage.googleapis.com/distroless/package_manager_tools/872f43c0f9b0f3d0d0c4d832edc59a1e4bd63e99/dpkg_parser.par'),
       executable = True,
-      sha256 = "e008f56117eaf12c6a7e60c47901419fa84a458e4732387f04d2101bae5c7c95",
+      sha256 = "ec12a77e02b1358434e15e1ce68b08501675350858a8e79599fb9e1064b051c0",
   )


### PR DESCRIPTION
Now dpkg_src rule supports retrieving Packages.gz file from arbitrary urls.