### PR TITLE
Remove hardcoded @package_bundle repo in cacerts.bzl.

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -16,7 +16,6 @@ passwd_file(
 )
 
 load("@package_bundle//file:packages.bzl", "packages")
-
 load("//cacerts:cacerts.bzl", "cacerts")
 
 cacerts(

--- a/base/BUILD
+++ b/base/BUILD
@@ -15,13 +15,14 @@ passwd_file(
     username = "root",
 )
 
+load("@package_bundle//file:packages.bzl", "packages")
+
 load("//cacerts:cacerts.bzl", "cacerts")
 
 cacerts(
     name = "cacerts",
+    deb = packages["ca-certificates"],
 )
-
-load("@package_bundle//file:packages.bzl", "packages")
 
 # Create /tmp, too many things assume it exists.
 # tmp.tar has a /tmp with the correct permissions 01777

--- a/cacerts/cacerts.bzl
+++ b/cacerts/cacerts.bzl
@@ -6,14 +6,12 @@ def _impl(ctx):
             inputs = [ctx.executable._extract, ctx.file.deb],
             outputs = [ctx.outputs.out])
 
-load("@package_bundle//file:packages.bzl", "packages")
-
 cacerts = rule(
     attrs = {
         "deb": attr.label(
-            default = Label(packages["ca-certificates"]),
             allow_files = [".deb"],
             single_file = True,
+            mandatory = True,
         ),
         # Implicit dependencies.
         "_extract": attr.label(


### PR DESCRIPTION
The current structure requires a `dpkg_list` named `package_bundle` to
always exist in the WORKSPACE file, which is not ideal if `dpkg_list` for
multiple distros (e.g. jessie, trusty, xenial) are declared at the same time.