### PR TITLE
Add a python3 distroless image 

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -18,6 +18,8 @@ docker_bundle(
         "gcr.io/{PROJECT_ID}/java:debug": "//java:debug",
         "gcr.io/{PROJECT_ID}/java/jetty:latest": "//java/jetty",
         "gcr.io/{PROJECT_ID}/java/jetty:debug": "//java/jetty:debug",
+        "gcr.io/{PROJECT_ID}/python3:latest": "//python3:python3",
+        "gcr.io/{PROJECT_ID}/python3:debug": "//python3:debug",
         "gcr.io/{PROJECT_ID}/python2.7:latest": "//python2.7:python27",
         "gcr.io/{PROJECT_ID}/python2.7:debug": "//python2.7:debug",
         "gcr.io/{PROJECT_ID}/nodejs:latest": "//nodejs",

--- a/BUILD.dotnet
+++ b/BUILD.dotnet
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "tar",
-    files = glob(["**/*"]),
+    srcs = glob(["**/*"]),
     package_dir = "/opt/dotnet",
     strip_prefix = ".",
 )

--- a/BUILD.jetty
+++ b/BUILD.jetty
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "tar",
-    files = glob(["**/*"]),
+    srcs = glob(["**/*"]),
     package_dir = "/jetty",
     # See: https://github.com/bazelbuild/bazel/issues/2176
     strip_prefix = ".",

--- a/BUILD.nodejs
+++ b/BUILD.nodejs
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "tar",
-    files = glob(["**/*"]),
+    srcs = glob(["**/*"]),
     package_dir = "/nodejs",
     # See: https://github.com/bazelbuild/bazel/issues/2176
     strip_prefix = ".",

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Follow these steps to get started:
   We publish the following distroless base images on `gcr.io`:
     * [gcr.io/distroless/base](base/README.md)
     * [gcr.io/distroless/python2.7](python2.7/README.md)
+    * [gcr.io/distroless/python3](python3/README.md)
     * [gcr.io/distroless/nodejs](nodejs/README.md)
     * [gcr.io/distroless/java](java/README.md)
     * [gcr.io/distroless/java/jetty](java/jetty/README/md)
@@ -68,6 +69,7 @@ See here for:
 
 * [Java](examples/java/BUILD)
 * [Python](examples/python2.7/BUILD)
+* [Python 3](examples/python3/BUILD)
 * [Golang](examples/go/BUILD)
 * [Node.js](examples/nodejs/BUILD)
 * [dotnet](examples/dotnet/BUILD)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,6 +46,7 @@ dpkg_list(
         "ca-certificates",
         "openssl",
         "libssl1.0.0",
+        "libexpat1",
         "netbase",
         "tzdata",
 
@@ -62,6 +63,11 @@ dpkg_list(
         "libpython2.7-minimal",
         "python2.7-minimal",
         "libpython2.7-stdlib",
+
+        #python3
+        "libpython3.4-minimal",
+        "python3.4-minimal",
+        "libpython3.4-stdlib",
 
         #dotnet
         "libcurl3",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,12 +3,14 @@ workspace(name = "distroless")
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.5.5",
+    tag = "0.7.0",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 
-go_repositories()
+go_rules_dependencies()
+
+go_register_toolchains()
 
 load(
     "//package_manager:package_manager.bzl",

--- a/examples/python3/BUILD
+++ b/examples/python3/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_docker//python:image.bzl", "py_image")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+
+py_image(
+    name = "hello_py",
+    srcs = ["hello.py"],
+    base = "//python3:python3",
+    main = "hello.py",
+)
+
+# This example runs a python program that walks the filesystem under "/etc" and prints every filename.
+docker_build(
+    name = "hello",
+    base = ":hello_py",
+    cmd = ["/etc"],
+)

--- a/examples/python3/hello.py
+++ b/examples/python3/hello.py
@@ -1,0 +1,31 @@
+#!/bin/python
+
+# Copyright 2017 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+
+parser = argparse.ArgumentParser()
+parser.add_argument('root', type=str,
+                    help='The root directory to walk.')
+
+def main(args):
+    """Prints the files that are inside the container, rooted at the first argument."""
+    for dirpath, _, files in os.walk(args.root):
+        for f in files:
+            print(os.path.join(dirpath, f))
+
+if __name__ == "__main__":
+    main(parser.parse_args())

--- a/python3/BUILD
+++ b/python3/BUILD
@@ -1,0 +1,34 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+load("@package_bundle//file:packages.bzl", "packages")
+
+[docker_build(
+    name = "python3" if not mode else mode[1:],
+    # Based on //cc so that C extensions work properly.
+    base = "//cc" + mode,
+    debs = [
+        packages["zlib1g"],
+        packages["libexpat1"],
+        packages["python3.4-minimal"],
+        packages["libpython3.4-minimal"],
+        packages["libpython3.4-stdlib"],
+    ],
+    entrypoint = [
+        "/usr/bin/python3.4",
+    ],
+    symlinks = {
+        "/usr/bin/python": "/usr/bin/python3.4",
+        "/usr/bin/python3": "/usr/bin/python3.4",
+    },
+) for mode in [
+    "",
+    ":debug",
+]]
+
+structure_test(
+    name = "python3_test",
+    config = "testdata/python3.yaml",
+    image = ":python3",
+)

--- a/python3/README.md
+++ b/python3/README.md
@@ -1,0 +1,15 @@
+# Documentation for `gcr.io/distroless/python27`
+
+## Image Contents
+
+This image contains a minimal Linux, Python-based runtime.
+
+Specifically, the image contains everything in the [base image](../base/README.md), plus:
+
+* Python 3 and its dependencies.
+
+## Usage
+
+The entrypoint of this image is set to "python", so this image expects users to supply a path to a .py file in the CMD.
+
+See the Python [Hello World](../examples/python3/) directory for an example.

--- a/python3/README.md
+++ b/python3/README.md
@@ -1,4 +1,4 @@
-# Documentation for `gcr.io/distroless/python27`
+# Documentation for `gcr.io/distroless/python3`
 
 ## Image Contents
 

--- a/python3/testdata/python3.yaml
+++ b/python3/testdata/python3.yaml
@@ -1,0 +1,14 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: hello
+    command: ["/usr/bin/python3", "-c", "print('Hello World')"]
+    expectedOutput: ['Hello World']
+  - name: version
+    command: ["/usr/bin/python3", "--version"]
+    expectedOutput: ["Python 3.4.2"]
+  - name: stdlib
+    command: ["/usr/bin/python3", "-c", "import argparse"]
+    exitCode: 0
+  - name: symlink 
+    command: ["/usr/bin/python", "--version"]
+    expectedOutput: ["Python 3.4.2"]


### PR DESCRIPTION
This should help with GoogleCloudPlatform/distroless#111 and
bazelbuild/rules_docker#229.

A few of caveats:
 * This still needs to be uploaded to gcr.io, presumably by some automated
   process that I'm not privy to.
 * This only tests importing a single module from the standard library
   (as with the 2.7 image).  I suspect there may be other dependencies
   which are required for other modules in the standard library; it
   would be nice to have tests for importing other modules which require
   additional dependencies.
 * Since the distroless base image is currently based on Debian Jessie, this
   uses version 3.4.2.  Ideally, we'd update distroless to be based on
   Stretch, and the newer versions of the dependent packages (across the
   board).  I suspect this would require some additional qualification
   on Google's end.