### PR TITLE
Use `srcs` instead of `files` in pkg_tar rules

### DIFF
--- a/BUILD.dotnet
+++ b/BUILD.dotnet
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "tar",
-    files = glob(["**/*"]),
+    srcs = glob(["**/*"]),
     package_dir = "/opt/dotnet",
     strip_prefix = ".",
 )

--- a/BUILD.jetty
+++ b/BUILD.jetty
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "tar",
-    files = glob(["**/*"]),
+    srcs = glob(["**/*"]),
     package_dir = "/jetty",
     # See: https://github.com/bazelbuild/bazel/issues/2176
     strip_prefix = ".",

--- a/BUILD.nodejs
+++ b/BUILD.nodejs
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "tar",
-    files = glob(["**/*"]),
+    srcs = glob(["**/*"]),
     package_dir = "/nodejs",
     # See: https://github.com/bazelbuild/bazel/issues/2176
     strip_prefix = ".",


### PR DESCRIPTION
The former is supported, while the latter is deprecated:
https://docs.bazel.build/versions/master/be/pkg.html#pkg_tar