### PR TITLE
Update to the latest `rules_go` release

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,12 +3,14 @@ workspace(name = "distroless")
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.5.5",
+    tag = "0.7.0",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 
-go_repositories()
+go_rules_dependencies()
+
+go_register_toolchains()
 
 load(
     "//package_manager:package_manager.bzl",


### PR DESCRIPTION
In theory, this should help support better cross compilation for things
like GoogleCloudPlatform/distroless#133.