### PR TITLE
Use the latest Python 3.6 in the python3 image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,6 +39,15 @@ dpkg_src(
     url = "http://snapshot.debian.org/archive",
 )
 
+dpkg_src(
+    name = "debian_buster",
+    arch = "amd64",
+    distro = "buster",
+    sha256 = "5113371655f80a25a67982360f1b5e33383281bf884aa12ab556b7a3613f031b",
+    snapshot = "20171101T160520Z",
+    url = "http://snapshot.debian.org/archive",
+)
+
 dpkg_list(
     name = "package_bundle",
     packages = [
@@ -65,9 +74,9 @@ dpkg_list(
         "libpython2.7-stdlib",
 
         #python3
-        "libpython3.5-minimal",
-        "python3.5-minimal",
-        "libpython3.5-stdlib",
+        "libpython3.6-minimal",
+        "python3.6-minimal",
+        "libpython3.6-stdlib",
 
         #dotnet
         "libcurl3",
@@ -81,6 +90,7 @@ dpkg_list(
     sources = [
         "@debian_stretch//file:Packages.json",
         "@debian_stretch_backports//file:Packages.json",
+        "@debian_buster//file:Packages.json",
     ],
 )
 

--- a/python3/BUILD
+++ b/python3/BUILD
@@ -11,16 +11,16 @@ load("@package_bundle//file:packages.bzl", "packages")
     debs = [
         packages["zlib1g"],
         packages["libexpat1"],
-        packages["python3.5-minimal"],
-        packages["libpython3.5-minimal"],
-        packages["libpython3.5-stdlib"],
+        packages["python3.6-minimal"],
+        packages["libpython3.6-minimal"],
+        packages["libpython3.6-stdlib"],
     ],
     entrypoint = [
-        "/usr/bin/python3.5",
+        "/usr/bin/python3.6",
     ],
     symlinks = {
-        "/usr/bin/python": "/usr/bin/python3.5",
-        "/usr/bin/python3": "/usr/bin/python3.5",
+        "/usr/bin/python": "/usr/bin/python3.6",
+        "/usr/bin/python3": "/usr/bin/python3.6",
     },
 ) for mode in [
     "",

--- a/python3/testdata/python3.yaml
+++ b/python3/testdata/python3.yaml
@@ -5,10 +5,10 @@ commandTests:
     expectedOutput: ['Hello World']
   - name: version
     command: ["/usr/bin/python3", "--version"]
-    expectedOutput: ["Python 3.5.3"]
+    expectedOutput: ["Python 3.6.3"]
   - name: stdlib
     command: ["/usr/bin/python3", "-c", "import argparse"]
     exitCode: 0
   - name: symlink 
     command: ["/usr/bin/python", "--version"]
-    expectedOutput: ["Python 3.5.3"]
+    expectedOutput: ["Python 3.6.3"]


### PR DESCRIPTION
Debian Stretch (which is the current stable and used as the base image
for `distroless`) doesn't have Python 3.6, nor will it.  Instead, we
grab the python3.6 packages from Debian Buster, which is the current
testing branch.

This falls heavily into the Works For Me category.  Since these images
are minimalist, using a package from `testing` shouldn't conflict with
other bits in the image, but my `dpkg`-fu is sufficiently weak that I
can't guarantee that.  It'd be nice to have somebody take a deeper look.