### PR TITLE
Update node.js version in README.md

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -6,7 +6,7 @@ This image contains a minimal Linux, Node.js-based runtime.
 
 Specifically, the image contains everything in the [base image](../base/README.md), plus:
 
-* Node.js v6.10.3 and its dependencies.
+* Node.js v8.9.1 and its dependencies.
 
 ## Usage
 


### PR DESCRIPTION
As of #127 the distroless nodejs image is using version 8. I updated the readme to reflect that change.