### PR TITLE
Fix consistency between openssl and libssl.so (#169)

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -67,7 +67,7 @@ docker_build(
     name = "base",
     debs = [
         packages["libc6"],
-        packages["libssl1.0.2"],
+        packages["libssl1.1"],
         packages["openssl"],
         packages["netbase"],
         packages["tzdata"],

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -5,7 +5,7 @@ load("@package_bundle//file:packages.bzl", "packages")
 
 # An intermediate image for Java and other "mostly statically" compiled languages
 [docker_build(
-    name = "cc" if not mode else mode[1:],
+    name = "cc" if (not mode) else mode[1:],
     base = "//base" + mode,
     debs = [
         packages["libgcc1"],

--- a/dotnet/BUILD
+++ b/dotnet/BUILD
@@ -4,7 +4,7 @@ load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("@package_bundle//file:packages.bzl", "packages")
 
 [docker_build(
-    name = "dotnet" if not mode else mode[1:],
+    name = "dotnet" if (not mode) else mode[1:],
     base = "//cc" + mode,
     debs = [
         packages["libcurl3"],

--- a/java/BUILD
+++ b/java/BUILD
@@ -10,7 +10,7 @@ cacerts_java(
 )
 
 [docker_build(
-    name = "java8" if not mode else mode[1:],
+    name = "java8" if (not mode) else mode[1:],
     base = "//cc" + mode,
     debs = [
         packages["zlib1g"],

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -3,7 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 
 [docker_build(
-    name = "nodejs" if not mode else mode[1:],
+    name = "nodejs" if (not mode) else mode[1:],
     base = "//cc" + mode,
     entrypoint = ["/nodejs/bin/node"],
     tars = ["@nodejs//:tar"],

--- a/python2.7/BUILD
+++ b/python2.7/BUILD
@@ -5,7 +5,7 @@ load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
 load("@package_bundle//file:packages.bzl", "packages")
 
 [docker_build(
-    name = "python27" if not mode else mode[1:],
+    name = "python27" if (not mode) else mode[1:],
     # Based on //cc so that C extensions work properly.
     base = "//cc" + mode,
     debs = [

--- a/python3/BUILD
+++ b/python3/BUILD
@@ -5,7 +5,7 @@ load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
 load("@package_bundle//file:packages.bzl", "packages")
 
 [docker_build(
-    name = "python3" if not mode else mode[1:],
+    name = "python3" if (not mode) else mode[1:],
     # Based on //cc so that C extensions work properly.
     base = "//cc" + mode,
     debs = [


### PR DESCRIPTION
Fixed inconsistency between openssl and libssl.so.

I checked the following behavior, I'm not familiar with Bazel, though.

```
$ PROJECT_ID=tmp bazel build :all
$ PROJECT_ID=tmp bazel run all

$ docker run -it gcr.io/lovot-services-dev/base:debug
/ # openssl version
OpenSSL 1.1.0f  25 May 2017
/ # find / | grep libssl.so
/usr/lib/x86_64-linux-gnu/libssl.so.1.1
```

```
$ bazel test --test_output=errors //...
INFO: Analysed 69 targets (26 packages loaded).
INFO: Found 56 targets and 13 test targets...
INFO: Elapsed time: 17.621s, Critical Path: 16.82s
INFO: Build completed successfully, 264 total actions
//base:base_test                                                         PASSED in 3.5s
//base:certs_test                                                        PASSED in 2.5s
//base:debug_test                                                        PASSED in 3.4s
//examples/dotnet:hello_test                                             PASSED in 4.6s
//examples/java:hello_test                                               PASSED in 5.5s
//examples/nodejs:hello_test                                             PASSED in 4.4s
//examples/nonroot:passwd_test                                           PASSED in 3.6s
//java:check_certs_test                                                  PASSED in 4.1s
//java:java8_test                                                        PASSED in 4.8s
//package_manager:parse_metadata_test                                    PASSED in 0.2s
//package_manager:util_test                                              PASSED in 0.2s
//python2.7:python27_test                                                PASSED in 8.6s
//python3:python3_test                                                   PASSED in 10.5s

Executed 13 out of 13 tests: 13 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```