### PR TITLE
WORKSPACE: Update Debian packages; Order security updates first

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,8 +25,8 @@ dpkg_src(
     name = "debian_stretch",
     arch = "amd64",
     distro = "stretch",
-    sha256 = "186cb62b5b21c778637c0aac0e74c3fdefcdd5853065645ace65503232eab25a",
-    snapshot = "20180130T043019Z",
+    sha256 = "4cb2fac3e32292613b92d3162e99eb8a1ed7ce47d1b142852b0de3092b25910c",
+    snapshot = "20180406T095535Z",
     url = "http://snapshot.debian.org/archive",
 )
 
@@ -34,22 +34,24 @@ dpkg_src(
     name = "debian_stretch_backports",
     arch = "amd64",
     distro = "stretch-backports",
-    sha256 = "bb4c9c16c4235376f71ea58b2e8c48428c10d5fd351d0caccd67cf1065bf9e52",
-    snapshot = "20180130T043019Z",
+    sha256 = "2863af9484d2d6b478ef225a8c740dac9a14015a594241a0872024c873123cdd",
+    snapshot = "20180406T095535Z",
     url = "http://snapshot.debian.org/archive",
 )
 
 dpkg_src(
     name = "debian_stretch_security",
-    package_prefix = "http://snapshot.debian.org/archive/debian-security/20180130T144658Z",
-    packages_gz_url = "http://snapshot.debian.org/archive/debian-security/20180130T144658Z/dists/jessie/updates/main/binary-amd64/Packages.gz",
-    sha256 = "98505e4de175ce7d33b9751d1b9a54380da7dbe19605f4b4ddafd88c115bce9c",
+    package_prefix = "http://snapshot.debian.org/archive/debian-security/20180405T165926Z/",
+    packages_gz_url = "http://snapshot.debian.org/archive/debian-security/20180405T165926Z/dists/stretch/updates/main/binary-amd64/Packages.gz",
+    sha256 = "a503fb4459eb9e862d080c7cf8135d7d395852e51cc7bfddf6c3d6cc4e11ee5f",
 )
 
 dpkg_list(
     name = "package_bundle",
     packages = [
-        "libc6",
+        # Version required to skip a security fix to the pre-release library
+        # TODO: Remove when there is a security fix or dpkg_list finds the recent version
+        "libc6=2.24-11+deb9u3",
         "ca-certificates",
         "openssl",
         "libssl1.0.2",
@@ -96,10 +98,13 @@ dpkg_list(
         "libuuid1",
         "liblzma5",
     ],
+    # Takes the first package found: security updates should go first
+    # If there was a security fix to a package before the stable release, this will find
+    # the older security release. This happened for stretch libc6.
     sources = [
-        "@debian_stretch//file:Packages.json",
-        "@debian_stretch_backports//file:Packages.json",
         "@debian_stretch_security//file:Packages.json",
+        "@debian_stretch_backports//file:Packages.json",
+        "@debian_stretch//file:Packages.json",
     ],
 )
 

--- a/package_manager/README.md
+++ b/package_manager/README.md
@@ -188,14 +188,14 @@ For a `dpkg_list` rule named `package_bundle`, packages can be used by loading `
       <td><code>packages</code></td>
       <td>
         <p><code>a string array of packages to download, required</code></p>
-        <p>The url that hosts snapshots of Packages.gz files.</p>
+        <p>The names of Debian packages that will be downloaded. You can optionally add <code>=version</code> to require a specific version.</p>
       </td>
     </tr>
     <tr>
       <td><code>sources</code></td>
       <td>
         <p><code>a list of outputs from dpkg_src, required</code></p>
-        <p>A list of snapshot sources that will be checked when downloading the package.  If a package is present in multiple sources, the first source in the list will be chosen.</p>
+        <p>A list of snapshot sources that will be checked when downloading the package.  If a package is present in multiple sources, the first source in the list will be chosen. This means security updates should be first.</p>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
The dpkg_list rule finds the first package from the sources attribute.
Previously the order was debian, backports, security. This means the security
updates were never applied. This switches the order and updates the snapshot
to the latest version.

The following packages are different after reordering:

```
openjdk-8-jre-headless: 8u151-b12-1~deb9u1 -> 8u162-b12-1~deb9u1
openssl 1.1.0f-3+deb9u1 -> 1.1.0f-3+deb9u2
libcurl3 7.52.1-5+deb9u4 -> 7.52.1-5+deb9u5
libc6 2.24-11+deb9u3 -> 2.24-11+deb9u1 *** older version!
libicu57 57.1-6+deb9u1 -> 57.1-6+deb9u2
libssl1.0.2 1.0.2l-2+deb9u2 -> 1.0.2l-2+deb9u3
libssl1.1 1.1.0f-3+deb9u1 -> 1.1.0f-3+deb9u2
libuuid1 2.29.2-1 -> 2.29.2-1+deb9u1
```

*** Note: libc6 indicates that dpkg_parser should parse and compare versions.
This is a security release that happened before the Debian Stretch release,
and there have not been any subsequent security updates. As a workaround, pin
the version of libc6.